### PR TITLE
Tailwind helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,9 @@ Lint/MissingSuper:
   Exclude:
     - app/components/**/*.rb
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ OR
 will render [this](https://play.tailwindcss.com/RT3Vvauu78)
 
 ```haml
-= tailwind_button_to action: "/users/sign_out", method: :delete)) do
+= tailwind_button_to action: "/users/sign_out", method: :delete do
   Sign Out
 ```
 
 OR
 
 ```
-= tailwind_button_to 'Sign Out', action: "/users/sign_out", method: :delete))
+= tailwind_button_to 'Sign Out', action: "/users/sign_out", method: :delete
 ```
 
 will render [this](https://play.tailwindcss.com/pJ8450tV21)

--- a/README.md
+++ b/README.md
@@ -19,21 +19,39 @@ Tramway use [Tailwind](https://tailwindcss.com/) by default. All UI helpers impl
 
 #### Button
 
-Tramway provides `Tailwinds::Navbar::ButtonComponent`, that uses `button_to` or `link_to`
+##### tailwind_button_to
+
+Tramway provides `tailwind_button_to` method, that uses `button_to` or `link_to`
 
 ```haml
-= render(Tailwinds::Navbar::ButtonComponent.new(href: "/users/sign_in")) do
+= tailwind_button_to href: "/users/sign_in" do
   Sign In
+```
+
+OR
+
+```haml
+= tailwind_button_to 'Sign In', href: "/users/sign_in"
 ```
 
 will render [this](https://play.tailwindcss.com/RT3Vvauu78)
 
 ```haml
-= render(Tailwinds::Navbar::ButtonComponent.new(action: "/users/sign_out", method: :delete)) do
+= tailwind_button_to action: "/users/sign_out", method: :delete)) do
   Sign Out
 ```
 
+OR
+
+```
+= tailwind_button_to 'Sign Out', action: "/users/sign_out", method: :delete))
+```
+
 will render [this](https://play.tailwindcss.com/pJ8450tV21)
+
+#### tailwind_link_to
+
+Tramway provides `tailwind_link_to` that is the alias of `tailwind_button_to`
 
 ## Contributing
 

--- a/app/components/tailwinds/navbar/button_component.rb
+++ b/app/components/tailwinds/navbar/button_component.rb
@@ -6,8 +6,6 @@ module Tailwinds
     #
     class ButtonComponent < TailwindComponent
       def initialize(**options)
-        raise 'You should provide `action` or `href` option' if !options[:action].present? && !options[:href].present?
-
         if options[:action].present?
           @action = options[:action]
         else

--- a/app/components/tailwinds/navbar/button_component.rb
+++ b/app/components/tailwinds/navbar/button_component.rb
@@ -6,6 +6,8 @@ module Tailwinds
     #
     class ButtonComponent < TailwindComponent
       def initialize(**options)
+        raise 'You should provide `action` or `href` option' if !options[:action].present? && !options[:href].present?
+
         if options[:action].present?
           @action = options[:action]
         else

--- a/lib/tramway.rb
+++ b/lib/tramway.rb
@@ -7,5 +7,4 @@ require 'view_component/engine'
 
 # Core module for the whole gem
 module Tramway
-  # Your code goes here...
 end

--- a/lib/tramway/engine.rb
+++ b/lib/tramway/engine.rb
@@ -5,5 +5,13 @@ module Tramway
   #
   class Engine < ::Rails::Engine
     isolate_namespace Tramway
+
+    initializer 'tramway.load_helpers' do
+      ActiveSupport.on_load(:action_view) do
+        require 'tramway/helpers/tailwind_helpers'
+
+        ActionView::Base.include Tramway::Helpers::TailwindHelpers
+      end
+    end
   end
 end

--- a/lib/tramway/helpers/tailwind_helpers.rb
+++ b/lib/tramway/helpers/tailwind_helpers.rb
@@ -7,6 +7,7 @@ module Tramway
     module TailwindHelpers
       def tailwind_clickable(text = nil, **options, &block)
         raise 'You can not provide argument and code block in the same time' if text.present? && block_given?
+        raise 'You should provide `action` or `href` option' if !options[:action].present? && !options[:href].present?
 
         if text.present?
           render(Tailwinds::Navbar::ButtonComponent.new(**options)) { text }

--- a/lib/tramway/helpers/tailwind_helpers.rb
+++ b/lib/tramway/helpers/tailwind_helpers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Tramway
+  module Helpers
+    # ActionView helpers for tailwind
+    #
+    module TailwindHelpers
+      def tailwind_clickable(text = nil, **options, &block)
+        raise 'You can not provide argument and code block in the same time' if text.present? && block_given?
+
+        if text.present?
+          render(Tailwinds::Navbar::ButtonComponent.new(**options)) { text }
+        else
+          render(Tailwinds::Navbar::ButtonComponent.new(**options), &block)
+        end
+      end
+
+      alias tailwind_button_to tailwind_clickable
+      alias tailwind_link_to tailwind_clickable
+    end
+  end
+end

--- a/spec/helpers/tailwind_helpers_spec.rb
+++ b/spec/helpers/tailwind_helpers_spec.rb
@@ -13,6 +13,7 @@ describe Tramway::Helpers::TailwindHelpers, type: :view do
 
   let(:path) { '/test' }
   let(:text) { 'Button Text' }
+  let(:block) { proc { text } }
 
   describe '#tailwind_clickable' do
     context 'with link rendering checks' do
@@ -29,8 +30,6 @@ describe Tramway::Helpers::TailwindHelpers, type: :view do
 
       context 'when a block is given' do
         it 'renders the Navbar::ButtonComponent with the provided options and block' do
-          block = proc { text }
-
           fragment = view.tailwind_clickable(**options, &block)
 
           expect(fragment).to have_content 'Button Text'
@@ -60,6 +59,26 @@ describe Tramway::Helpers::TailwindHelpers, type: :view do
           expect(fragment).to have_content 'Button Text'
           expect(fragment).to have_css "form[action='#{path}']"
         end
+      end
+    end
+
+    context 'with raising errors' do
+      it 'raises error in case there are text and block in the same time' do
+        expect { view.tailwind_clickable(text, &block) }.to(
+          raise_error 'You can not provide argument and code block in the same time'
+        )
+      end
+
+      it 'raises error in case there is only text without options' do
+        expect { view.tailwind_clickable(text) }.to(
+          raise_error 'You should provide `action` or `href` option'
+        )
+      end
+
+      it 'raises error in case there is only block without options' do
+        expect { view.tailwind_clickable(&block) }.to(
+          raise_error 'You should provide `action` or `href` option'
+        )
       end
     end
   end

--- a/spec/helpers/tailwind_helpers_spec.rb
+++ b/spec/helpers/tailwind_helpers_spec.rb
@@ -1,0 +1,59 @@
+# spec/tramway/helpers/tailwind_helpers_spec.rb
+
+require 'rails_helper'
+
+describe Tramway::Helpers::TailwindHelpers, type: :helper do
+  let(:helper) { Class.new { include Tramway::Helpers::TailwindHelpers }.new }
+  
+  describe '#tailwind_clickable' do
+    context 'when text is provided' do
+      it 'renders the Navbar::ButtonComponent with the provided text' do
+        text = 'Button Text'
+        options = { class: 'button' }
+        component_double = instance_double('Tailwinds::Navbar::ButtonComponent')
+
+        expect(Tailwinds::Navbar::ButtonComponent)
+          .to receive(:new)
+          .with(options)
+          .and_return(component_double)
+
+        helper.tailwind_clickable(text, options)
+      end
+    end
+
+    context 'when a block is given' do
+      it 'renders the Navbar::ButtonComponent with the provided options and block' do
+        options = { class: 'button' }
+        component_double = instance_double('Tailwinds::Navbar::ButtonComponent')
+        block = proc { 'Button Block' }
+
+        expect(Tailwinds::Navbar::ButtonComponent)
+          .to receive(:new)
+          .with(options)
+          .and_return(component_double)
+
+        expect(helper).to receive(:render)
+          .with(component_double)
+          .and_yield
+
+        expect(helper).to receive(:instance_exec)
+          .with(&block)
+
+        helper.tailwind_clickable(options, &block)
+      end
+    end
+  end
+
+  describe '#tailwind_button_to' do
+    it 'is an alias for tailwind_clickable' do
+      expect(helper.method(:tailwind_button_to)).to eq(helper.method(:tailwind_clickable))
+    end
+  end
+
+  describe '#tailwind_link_to' do
+    it 'is an alias for tailwind_clickable' do
+      expect(helper.method(:tailwind_link_to)).to eq(helper.method(:tailwind_clickable))
+    end
+  end
+end
+

--- a/spec/helpers/tailwind_helpers_spec.rb
+++ b/spec/helpers/tailwind_helpers_spec.rb
@@ -1,59 +1,82 @@
+# frozen_string_literal: true
+
 # spec/tramway/helpers/tailwind_helpers_spec.rb
 
 require 'rails_helper'
+require 'support/view_helpers'
 
-describe Tramway::Helpers::TailwindHelpers, type: :helper do
-  let(:helper) { Class.new { include Tramway::Helpers::TailwindHelpers }.new }
-  
+describe Tramway::Helpers::TailwindHelpers, type: :view do
+  before do
+    described_class.include ViewHelpers
+    view.extend Tramway::Helpers::TailwindHelpers
+  end
+
+  let(:path) { '/test' }
+  let(:text) { 'Button Text' }
+
   describe '#tailwind_clickable' do
-    context 'when text is provided' do
-      it 'renders the Navbar::ButtonComponent with the provided text' do
-        text = 'Button Text'
-        options = { class: 'button' }
-        component_double = instance_double('Tailwinds::Navbar::ButtonComponent')
+    context 'with link rendering checks' do
+      let(:options) { { href: path } }
 
-        expect(Tailwinds::Navbar::ButtonComponent)
-          .to receive(:new)
-          .with(options)
-          .and_return(component_double)
+      context 'when text is provided' do
+        it 'renders the Navbar::ButtonComponent with the provided text' do
+          fragment = view.tailwind_clickable(text, **options)
 
-        helper.tailwind_clickable(text, options)
+          expect(fragment).to have_content 'Button Text'
+          expect(fragment).to have_css "a[href='#{path}']"
+        end
+      end
+
+      context 'when a block is given' do
+        it 'renders the Navbar::ButtonComponent with the provided options and block' do
+          block = proc { text }
+
+          fragment = view.tailwind_clickable(**options, &block)
+
+          expect(fragment).to have_content 'Button Text'
+          expect(fragment).to have_css "a[href='#{path}']"
+        end
       end
     end
 
-    context 'when a block is given' do
-      it 'renders the Navbar::ButtonComponent with the provided options and block' do
-        options = { class: 'button' }
-        component_double = instance_double('Tailwinds::Navbar::ButtonComponent')
-        block = proc { 'Button Block' }
+    context 'with button rendering checks' do
+      let(:options) { { action: path, method: %i[get post patch put delete].sample } }
 
-        expect(Tailwinds::Navbar::ButtonComponent)
-          .to receive(:new)
-          .with(options)
-          .and_return(component_double)
+      context 'when text is provided' do
+        it 'renders the Navbar::ButtonComponent with the provided text' do
+          fragment = view.tailwind_clickable(text, **options)
 
-        expect(helper).to receive(:render)
-          .with(component_double)
-          .and_yield
+          expect(fragment).to have_content 'Button Text'
+          expect(fragment).to have_css "form[action='#{path}']"
+        end
+      end
 
-        expect(helper).to receive(:instance_exec)
-          .with(&block)
+      context 'when a block is given' do
+        it 'renders the Navbar::ButtonComponent with the provided options and block' do
+          block = proc { text }
 
-        helper.tailwind_clickable(options, &block)
+          fragment = view.tailwind_clickable(**options, &block)
+
+          expect(fragment).to have_content 'Button Text'
+          expect(fragment).to have_css "form[action='#{path}']"
+        end
       end
     end
   end
 
-  describe '#tailwind_button_to' do
-    it 'is an alias for tailwind_clickable' do
-      expect(helper.method(:tailwind_button_to)).to eq(helper.method(:tailwind_clickable))
-    end
-  end
+  context 'with aliases checks' do
+    let(:helper) { Class.new { include Tramway::Helpers::TailwindHelpers }.new }
 
-  describe '#tailwind_link_to' do
-    it 'is an alias for tailwind_clickable' do
-      expect(helper.method(:tailwind_link_to)).to eq(helper.method(:tailwind_clickable))
+    describe '#tailwind_button_to' do
+      it 'is an alias for tailwind_clickable' do
+        expect(helper.method(:tailwind_button_to)).to eq(helper.method(:tailwind_clickable))
+      end
+    end
+
+    describe '#tailwind_link_to' do
+      it 'is an alias for tailwind_clickable' do
+        expect(helper.method(:tailwind_link_to)).to eq(helper.method(:tailwind_clickable))
+      end
     end
   end
 end
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,13 +7,13 @@ require 'rspec/rails'
 require 'view_component/test_helpers'
 require 'view_component/system_test_helpers'
 require 'capybara/rspec'
+require 'tramway/helpers/tailwind_helpers'
+
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
-
-  config.include ViewComponent::TestHelpers, type: :helper
-  config.include ViewComponent::SystemTestHelpers, type: :helper
-  config.include Capybara::RSpecMatchers, type: :helper
+  config.include Capybara::RSpecMatchers, type: :view
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,4 +12,8 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+
+  config.include ViewComponent::TestHelpers, type: :helper
+  config.include ViewComponent::SystemTestHelpers, type: :helper
+  config.include Capybara::RSpecMatchers, type: :helper
 end

--- a/spec/support/view_helpers.rb
+++ b/spec/support/view_helpers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ViewHelpers
+  def to_partial_path; end
+end


### PR DESCRIPTION
## What's changed basically?

Now we have 2 more helpers
* `tailwind_button_to`
* `tailwind_link_to`

## What's changed for tramway drivers?

### Before

```haml
= render(Tailwinds::Navbar::ButtonComponent.new(href: "/users/sign_in")) do
  Sign In

= render(Tailwinds::Navbar::ButtonComponent.new(action: "/users/sign_out", method: :delete)) do
  Sign Out
```

### After

```haml
= tailwind_button_to href: "/users/sign_in" do
  Sign In

= tailwind_button_to 'Sign In', href: "/users/sign_in"

= tailwind_button_to action: "/users/sign_out", method: :delete do
  Sign Out

= tailwind_button_to 'Sign Out', action: "/users/sign_out", method: :delete
```

Find more info [here](https://github.com/Purple-Magic/tramway/blob/tailwind_helpers/README.md#button)