### PR TITLE
Issue #27. Implement title_link option for Tramway Navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This helper provides several options. Here is YAML view of `tramway_navbar` opti
 
 ```yaml
 title: String that will be added to the left side of the navbar
+title_link: Link on Tramway Navbar title. Default: '/'
 background:
   color: Css-color. Supports all named CSS colors and HEX colors
   intensity: Color intensity. Range: **100..950**. Used by Tailwind. Not supported in case of using HEX color in the background.color

--- a/app/components/tailwinds/navbar_component.html.haml
+++ b/app/components/tailwinds/navbar_component.html.haml
@@ -1,9 +1,10 @@
 %nav.py-4.px-8.flex.justify-between.items-center{ class: "bg-#{@color}" }
-  - if @title.present? || @left_items.present?
+  - if @title[:text].present? || @left_items.present?
     .flex
-      - if @title.present?
-        .text-xl.text-white.font-bold
-          = @title
+      - if @title[:text].present?
+        = link_to @title[:link] do
+          .text-xl.text-white.font-bold
+            = @title[:text]
       - if @left_items.present?
         %ul.flex.items-center.space-x-4
           - @left_items.each do |item|

--- a/app/components/tailwinds/navbar_component.rb
+++ b/app/components/tailwinds/navbar_component.rb
@@ -33,7 +33,7 @@ module Tailwinds
     include Tailwinds::BackgroundHelper
 
     def initialize(**options)
-      @title = options[:title]
+      @title = { text: options[:title], link: options[:title_link] || '/' }
       @left_items = options[:left_items]
       @right_items = options[:right_items]
       @color = BackgroundHelper.background(options)

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -26,10 +26,30 @@ describe Tramway::Helpers::NavbarHelper, type: :view do
         expect(fragment).to have_css 'nav.bg-purple-700.py-4.px-8.flex.justify-between.items-center'
       end
 
-      it 'renders navbar with title' do
-        fragment = view.tramway_navbar(title:)
+      context 'with title checks' do
+        it 'renders navbar with title' do
+          fragment = view.tramway_navbar(title:)
 
-        expect(fragment).to have_content title
+          expect(fragment).to have_content title
+        end
+
+        it 'renders navbar with default title link' do
+          fragment = view.tramway_navbar(title:)
+
+          expect(fragment).to have_css "a[href='/']"
+        end
+
+        it 'renders navbar with specific title link' do
+          fragment = view.tramway_navbar(title:, title_link: '/home')
+
+          expect(fragment).to have_css "a[href='/home']"
+        end
+
+        it 'does not renders title in case user did not provide it' do
+          fragment = view.tramway_navbar(title_link: '/home')
+
+          expect(fragment).not_to have_css "a[href='/home']"
+        end
       end
 
       context 'with left and right items checks' do

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -27,15 +27,10 @@ describe Tramway::Helpers::NavbarHelper, type: :view do
       end
 
       context 'with title checks' do
-        it 'renders navbar with title' do
+        it 'renders navbar with title and default link' do
           fragment = view.tramway_navbar(title:)
 
           expect(fragment).to have_content title
-        end
-
-        it 'renders navbar with default title link' do
-          fragment = view.tramway_navbar(title:)
-
           expect(fragment).to have_css "a[href='/']"
         end
 


### PR DESCRIPTION
## What's changed basically?

`tramway_navbar` has 1 one more option: `title_link`

## What's changed for tramway drivers?

### Before

```haml
= tramway_navbar title: 'RED MAGIC'
```

### After

```haml
= tramway_navbar title: 'RED MAGIC', title_link: '/home'
```

More docs [here](https://github.com/Purple-Magic/tramway/pull/28/commits/0dde7ad675ac11bca8141843c00c363ba37a290a)

Closes #27 

Will be merged on July, 2