### PR TITLE
Add entities route option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ end
 
 By default, links to the Tramway Entities index page are rendered in [Tramway Navbar](https://github.com/Purple-Magic/tramway#tramway-navbar).
 
+#### Define entities with options
+
+Tramway Entity supports several options that are used in different features.
+
+**route**
+
+```ruby
+Tramway.configure do |config|
+  config.entities = [
+    { name: :user, route: { namespace: :admin } },                                 # `admin_users_path` link in the Tramway Navbar
+    { name: :podcast, route: { route_method: :shows } },                           # `shows_path` link in the Tramway Navbar
+    { name: :episodes, route: { namespace: :podcasts, route_method: :episodes } }, # `podcasts_episodes_path` link in the Tramway Navbar
+  ]
+end
+```
+
 ### Tailwind components
 
 Tramway uses [Tailwind](https://tailwindcss.com/) by default. All UI helpers are implemented with [ViewComponent](https://github.com/viewcomponent/view_component).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tramway Entity supports several options that are used in different features.
 
 **route**
 
+*config/initializers/tramway.rb*
 ```ruby
 Tramway.configure do |config|
   config.entities = [

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -9,7 +9,7 @@ Now we have 2 more helpers
 
 ## What's changed for tramway drivers?
 
-*Here is description how it was before and after*
+*Here is the description of how it was before and after*
 
 *Example*
 
@@ -29,3 +29,4 @@ Now we have 2 more helpers
 *You should make updates in the docs in a single commit if it's possible. Link it here*
 
 Find more info [here](https://github.com/Purple-Magic/tramway/blob/tailwind_helpers/README.md#button)
+

--- a/lib/tramway.rb
+++ b/lib/tramway.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'types'
 require 'tramway/version'
 require 'tramway/engine'
 require 'tramway/base_decorator'

--- a/lib/tramway/config.rb
+++ b/lib/tramway/config.rb
@@ -15,7 +15,9 @@ module Tramway
 
     def entities=(collection)
       @entities = collection.map do |entity|
-        Tramway::Configs::Entity.new(name: entity)
+        entity_options = entity.is_a?(Hash) ? entity : { name: entity }
+
+        Tramway::Configs::Entity.new(**entity_options)
       end
     end
 

--- a/lib/tramway/configs/entities/route.rb
+++ b/lib/tramway/configs/entities/route.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 module Tramway
   module Configs
     module Entities
+      # Route struct describes rules for route management
+      #
       class Route < Dry::Struct
         attribute? :namespace, Types::Coercible::String
         attribute? :route_method, Types::Coercible::String

--- a/lib/tramway/configs/entities/route.rb
+++ b/lib/tramway/configs/entities/route.rb
@@ -1,0 +1,14 @@
+module Tramway
+  module Configs
+    module Entities
+      class Route < Dry::Struct
+        attribute? :namespace, Types::Coercible::String
+        attribute? :route_method, Types::Coercible::String
+
+        def helper_method_by(underscored_name)
+          "#{[namespace, route_method || underscored_name].compact.join('_')}_path"
+        end
+      end
+    end
+  end
+end

--- a/lib/tramway/configs/entity.rb
+++ b/lib/tramway/configs/entity.rb
@@ -1,24 +1,42 @@
 # frozen_string_literal: true
 
+require 'tramway/configs/entities/route'
+
 module Tramway
   module Configs
     # Tramway is entity based framework
     #
-    class Entity
-      attr_reader :name
-
-      def initialize(name:)
-        @name = name.to_s
-      end
+    class Entity < Dry::Struct
+      attribute :name, Types::Coercible::String
+      attribute? :route, Tramway::Configs::Entities::Route
 
       def routes
-        underscored_name = name.parameterize.pluralize.underscore
-
-        OpenStruct.new index: Rails.application.routes.url_helpers.public_send("#{underscored_name}_path")
+        OpenStruct.new index: Rails.application.routes.url_helpers.public_send(route_helper_method)
       end
 
       def human_name
-        OpenStruct.new single: name.capitalize, plural: name.pluralize.capitalize
+        options = if model_class.present?
+                    { single: model_class.model_name.human, plural: model_class.model_name.human.pluralize }
+                  else
+                    { single: name.capitalize, plural: name.pluralize.capitalize }
+                  end
+        OpenStruct.new **options
+      end
+
+      private
+
+      def model_class
+        name.camelize.constantize if defined?(name.camelize.constantize)
+      end
+
+      def route_helper_method
+        underscored_name = name.parameterize.pluralize.underscore
+
+        if route.present?
+          route.helper_method_by(underscored_name)
+        else
+          "#{underscored_name}_path"
+        end
       end
     end
   end

--- a/lib/tramway/configs/entity.rb
+++ b/lib/tramway/configs/entity.rb
@@ -26,7 +26,11 @@ module Tramway
       private
 
       def model_class
-        name.camelize.constantize if defined?(name.camelize.constantize)
+        begin
+          name.camelize.constantize
+        rescue StandardError => e
+          nil
+        end
       end
 
       def route_helper_method

--- a/lib/tramway/configs/entity.rb
+++ b/lib/tramway/configs/entity.rb
@@ -4,8 +4,7 @@ require 'tramway/configs/entities/route'
 
 module Tramway
   module Configs
-    # Tramway is entity based framework
-    #
+    # Tramway is an entity-based framework
     class Entity < Dry::Struct
       attribute :name, Types::Coercible::String
       attribute? :route, Tramway::Configs::Entities::Route
@@ -16,21 +15,20 @@ module Tramway
 
       def human_name
         options = if model_class.present?
-                    { single: model_class.model_name.human, plural: model_class.model_name.human.pluralize }
+                    model_name = model_class.model_name.human
+                    { single: model_name, plural: model_name.pluralize }
                   else
                     { single: name.capitalize, plural: name.pluralize.capitalize }
                   end
-        OpenStruct.new **options
+        OpenStruct.new(**options)
       end
 
       private
 
       def model_class
-        begin
-          name.camelize.constantize
-        rescue StandardError => e
-          nil
-        end
+        name.camelize.constantize
+      rescue StandardError
+        nil
       end
 
       def route_helper_method

--- a/lib/tramway/navbar.rb
+++ b/lib/tramway/navbar.rb
@@ -51,8 +51,6 @@ module Tramway
       filling_side :left
 
       entities.each do |entity|
-        entity.to_s.pluralize
-
         item entity.human_name.plural, entity.routes.index
       end
 

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -1,0 +1,5 @@
+require 'dry-struct'
+
+module Types
+  include Dry.Types()
+end

--- a/lib/types.rb
+++ b/lib/types.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'dry-struct'
 
+# We need because of this https://dry-rb.org/gems/dry-struct/1.6/recipes/
 module Types
   include Dry.Types()
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,8 +4,14 @@ Rails.application.routes.draw do
   mount Tramway::Engine => '/tramway'
 
   resources :users
+  resources :clients
 
   namespace :episodes do
     resources :parts
+  end
+
+  namespace :admin do
+    resources :users
+    resources :clients
   end
 end

--- a/spec/tramway/configs/entities/route_spec.rb
+++ b/spec/tramway/configs/entities/route_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # spec/route_spec.rb
 require 'spec_helper'
 require 'tramway/configs/entities/route' # Adjust the path to the Route class

--- a/spec/tramway/configs/entities/route_spec.rb
+++ b/spec/tramway/configs/entities/route_spec.rb
@@ -1,0 +1,37 @@
+# spec/route_spec.rb
+require 'spec_helper'
+require 'tramway/configs/entities/route' # Adjust the path to the Route class
+
+RSpec.describe Tramway::Configs::Entities::Route do
+  describe '#helper_method_by' do
+    let(:route) { described_class.new(namespace: :admin, route_method: :clients) }
+
+    it 'returns the correct helper method name' do
+      expect(route.helper_method_by('custom_name')).to eq('admin_clients_path')
+    end
+
+    context 'when route_method is not provided' do
+      let(:route) { described_class.new(namespace: :admin) }
+
+      it 'uses the underscored_name as a fallback' do
+        expect(route.helper_method_by('custom_name')).to eq('admin_custom_name_path')
+      end
+    end
+
+    context 'when namespace is not provided' do
+      let(:route) { described_class.new(route_method: 'clients') }
+
+      it 'uses the route_method as the method name' do
+        expect(route.helper_method_by('custom_name')).to eq('clients_path')
+      end
+    end
+
+    context 'when both namespace and route_method are not provided' do
+      let(:route) { described_class.new }
+
+      it 'uses the underscored_name as a fallback' do
+        expect(route.helper_method_by('custom_name')).to eq('custom_name_path')
+      end
+    end
+  end
+end

--- a/spec/tramway/configs/entity_spec.rb
+++ b/spec/tramway/configs/entity_spec.rb
@@ -22,33 +22,15 @@ shared_examples 'Tramway Config Entity human_name' do |name|
   end
 end
 
-shared_examples 'Tramway Config Entity routes' do |name, route|
-  subject { described_class.new(name:, route:) }
-
+shared_examples 'Tramway Config Entity routes' do
   describe '#routes' do
     it 'returns an OpenStruct object with index route' do
       expect(subject.routes).to be_an(OpenStruct)
       expect(subject.routes).to respond_to(:index)
     end
 
-    let(:expected_route) do
-      helper = if route.present?
-                 if route[:namespace].present? && route[:route_method].nil?
-                   "#{route[:namespace]}_#{name.to_s.pluralize.parameterize.underscore}_path"
-                 elsif route[:namespace].present? && route[:route_method].present?
-                   "#{route[:namespace]}_#{route[:route_method]}_path"
-                 elsif route[:namespace].nil? && route[:route_method].present?
-                   "#{route[:route_method]}_path"
-                 end
-               else
-                 "#{name.to_s.pluralize.parameterize.underscore}_path"
-               end
-
-      Rails.application.routes.url_helpers.public_send helper
-    end
-
     it 'sets the correct index route' do
-      expect(subject.routes.index).to eq(expected_route)
+      expect(subject.routes.index).to eq(Rails.application.routes.url_helpers.public_send(helper))
     end
   end
 end
@@ -59,26 +41,45 @@ describe Tramway::Configs::Entity do
       entity = :user
 
       include_examples 'Tramway Config Entity human_name', entity
-      include_examples 'Tramway Config Entity routes', entity
     end
 
     context 'with entity with namespaces' do
       entity = 'episodes/part'
 
       include_examples 'Tramway Config Entity human_name', entity
-      include_examples 'Tramway Config Entity routes', entity
     end
   end
 
   context 'with entity name and route contains namespace only' do
-    include_examples 'Tramway Config Entity routes', :user, { namespace: :admin }
+    let(:name) { :user }
+    let(:route) { { namespace: :admin } }
+
+    subject { described_class.new(name:, route:) }
+
+    let(:helper) { "#{route[:namespace]}_#{name.to_s.pluralize}_path" }
+
+    include_examples 'Tramway Config Entity routes'
   end
 
   context 'with entity name and route contains namespace and route_method' do
-    include_examples 'Tramway Config Entity routes', :user, { namespace: :admin, route_method: :clients }
+    let(:name) { :user }
+    let(:route) { { namespace: :admin, route_method: :clients } }
+
+    subject { described_class.new(name:, route:) }
+
+    let(:helper) { "#{route[:namespace]}_#{route[:route_method]}_path" }
+
+    include_examples 'Tramway Config Entity routes'
   end
 
   context 'with entity name and route contains route_method only' do
-    include_examples 'Tramway Config Entity routes', :user, { route_method: :clients }
+    let(:name) { :user }
+    let(:route) { { route_method: :clients } }
+
+    subject { described_class.new(name:, route:) }
+
+    let(:helper) { "#{route[:route_method]}_path" }
+
+    include_examples 'Tramway Config Entity routes'
   end
 end

--- a/spec/tramway/configs/entity_spec.rb
+++ b/spec/tramway/configs/entity_spec.rb
@@ -2,29 +2,8 @@
 
 require 'rails_helper'
 
-shared_examples 'Tramway Config Entity' do |name|
+shared_examples 'Tramway Config Entity human_name' do |name|
   subject { described_class.new(name:) }
-
-  describe '#initialize' do
-    it 'sets the correct name' do
-      expect(subject.name).to eq(name.to_s)
-    end
-  end
-
-  describe '#routes' do
-    it 'returns an OpenStruct object with index route' do
-      expect(subject.routes).to be_an(OpenStruct)
-      expect(subject.routes).to respond_to(:index)
-    end
-
-    let(:expected_route) do
-      Rails.application.routes.url_helpers.public_send("#{name.to_s.pluralize.parameterize.underscore}_path")
-    end
-
-    it 'sets the correct index route' do
-      expect(subject.routes.index).to eq(expected_route)
-    end
-  end
 
   describe '#human_name' do
     it 'returns an OpenStruct object with single and plural human names' do
@@ -43,12 +22,63 @@ shared_examples 'Tramway Config Entity' do |name|
   end
 end
 
+shared_examples 'Tramway Config Entity routes' do |name, route|
+  subject { described_class.new(name:, route:) }
+
+  describe '#routes' do
+    it 'returns an OpenStruct object with index route' do
+      expect(subject.routes).to be_an(OpenStruct)
+      expect(subject.routes).to respond_to(:index)
+    end
+
+    let(:expected_route) do
+      helper = if route.present?
+                 if route[:namespace].present? && route[:route_method].nil?
+                   "#{route[:namespace]}_#{name.to_s.pluralize.parameterize.underscore}_path"
+                 elsif route[:namespace].present? && route[:route_method].present?
+                   "#{route[:namespace]}_#{route[:route_method]}_path"
+                 elsif route[:namespace].nil? && route[:route_method].present?
+                   "#{route[:route_method]}_path"
+                 end
+               else
+                 "#{name.to_s.pluralize.parameterize.underscore}_path"
+               end
+
+      Rails.application.routes.url_helpers.public_send helper
+    end
+
+    it 'sets the correct index route' do
+      expect(subject.routes.index).to eq(expected_route)
+    end
+  end
+end
+
 describe Tramway::Configs::Entity do
-  context 'with entity without namespaces' do
-    include_examples 'Tramway Config Entity', :user
+  context 'with entity name' do
+    context 'with entity without namespaces' do
+      entity = :user
+
+      include_examples 'Tramway Config Entity human_name', entity
+      include_examples 'Tramway Config Entity routes', entity
+    end
+
+    context 'with entity with namespaces' do
+      entity = 'episodes/part'
+
+      include_examples 'Tramway Config Entity human_name', entity
+      include_examples 'Tramway Config Entity routes', entity
+    end
   end
 
-  context 'with entity with namespaces' do
-    include_examples 'Tramway Config Entity', 'episodes/part'
+  context 'with entity name and route contains namespace only' do
+    include_examples 'Tramway Config Entity routes', :user, { namespace: :admin }
+  end
+
+  context 'with entity name and route contains namespace and route_method' do
+    include_examples 'Tramway Config Entity routes', :user, { namespace: :admin, route_method: :clients }
+  end
+
+  context 'with entity name and route contains route_method only' do
+    include_examples 'Tramway Config Entity routes', :user, { route_method: :clients }
   end
 end

--- a/tramway.gemspec
+++ b/tramway.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'haml-rails'
   spec.add_dependency 'dry-struct'
+  spec.add_dependency 'haml-rails'
   spec.add_dependency 'rails', '~> 7'
   spec.add_dependency 'view_component'
 

--- a/tramway.gemspec
+++ b/tramway.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'haml-rails'
+  spec.add_dependency 'dry-struct'
   spec.add_dependency 'rails', '~> 7'
   spec.add_dependency 'view_component'
 


### PR DESCRIPTION
## What's changed basically?

*Here are changes in a named list*

Now we have the `route` option in Tramway Entity.

## What's changed for tramway drivers?

*Here is the description of how it was before and after*

*Example*

### Before

*config/initializers/tramway.rb*
```ruby
Tramway.configure do |config|
  config.entities = [ :user, :podcast, :episode ]
end
```

### After

#### Define entities with options

Tramway Entity supports several options that are used in different features.

**route**

```ruby
Tramway.configure do |config|
  config.entities = [
    { name: :user, route: { namespace: :admin } },                                 # `admin_users_path` link in the Tramway Navbar
    { name: :podcast, route: { route_method: :shows } },                           # `shows_path` link in the Tramway Navbar
    { name: :episodes, route: { namespace: :podcasts, route_method: :episodes } }, # `podcasts_episodes_path` link in the Tramway Navbar
  ]
end
```

This PR will be merged on 17, Aug