### PR TITLE
Added Tailwind Form Builder

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -5,6 +5,9 @@ detectors:
   BooleanParameter:
     exclude:
       - "Tramway::BaseForm"
+  DataClump:
+    exclude:
+      - "Tailwinds::Form::Builder"
 
 directories:
   "spec/dummy/db/migrate/":

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/README.md
+++ b/README.md
@@ -322,11 +322,11 @@ Tramway uses [Tailwind](https://tailwindcss.com/) by default. All UI helpers are
 Tramway provides `tramway_form_for` helper that renders Tailwind-styled forms by default.
 
 ```ruby
-tramway_form_for user do |f|
-  f.text_field :email
-  f.password_field :password
-  f.file_field :file
-  tailwind_submit_button "Create User"
+= tramway_form_for User.new do |f|
+  = f.text_field :text
+  = f.password_field :password
+  = f.file_field :file
+  = tailwind_submit_button "Create User"
 ```
 
 will render [this](https://play.tailwindcss.com/xho3LfjKkK)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Unite Ruby on Rails brilliance. Streamline development with Tramway.
   * [Tramway Decorators](https://github.com/Purple-Magic/tramway#tramway-decorators)
   * [Tramway Form](https://github.com/Purple-Magic/tramway#tramway-form)
   * [Tramway Navbar](https://github.com/Purple-Magic/tramway#tramway-navbar)
+  * [Tailwind-styled forms](https://github.com/Purple-Magic/tramway#tailwind-styled-forms)
 
 ## Installation
 Add this line to your application's Gemfile:
@@ -312,9 +313,27 @@ tramway_navbar title: 'Purple Magic' do |nav|
 end
 ```
 
-### Tailwind components
+### Tailwind-styled forms
 
 Tramway uses [Tailwind](https://tailwindcss.com/) by default. All UI helpers are implemented with [ViewComponent](https://github.com/viewcomponent/view_component).
+
+#### tramway_form_for
+
+Tramway provides `tramway_form_for` helper that renders Tailwind-styled forms by default.
+
+```ruby
+tramway_form_for user do |f|
+  f.text_field :email
+  f.password_field :password
+  f.file_field :file
+  tailwind_submit_button "Create User"
+```
+
+Available form helpers:
+* text_field
+* password_field
+* file_field
+* tailwind_submit_button
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ tramway_form_for user do |f|
   tailwind_submit_button "Create User"
 ```
 
+will render [this](https://play.tailwindcss.com/xho3LfjKkK)
+
 Available form helpers:
 * text_field
 * password_field

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Tramway provides `tramway_form_for` helper that renders Tailwind-styled forms by
   = f.text_field :text
   = f.password_field :password
   = f.file_field :file
-  = tailwind_submit_button "Create User"
+  = f.submit "Create User"
 ```
 
 will render [this](https://play.tailwindcss.com/xho3LfjKkK)
@@ -335,7 +335,7 @@ Available form helpers:
 * text_field
 * password_field
 * file_field
-* tailwind_submit_button
+* submit
 
 ## Contributing
 

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -1,28 +1,33 @@
 # frozen_string_literal: true
 
-class Tailwinds::Form::Builder < Tramway::Views::FormBuilder
-  def text_field(attribute, **options, &)
-    input = super(attribute, **options.merge(class: text_input_class))
-    render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
-  end
+module Tailwinds
+  module Form
+    # Provides Tailwind-styled forms
+    class Builder < Tramway::Views::FormBuilder
+      def text_field(attribute, **options, &)
+        input = super(attribute, **options.merge(class: text_input_class))
+        render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
+      end
 
-  alias password_field text_field
+      alias password_field text_field
 
-  def file_field(attribute, **options, &)
-    input = super(
-      attribute,
-      **options.merge(
-        class: :hidden,
-        onchange: "document.getElementById('#{attribute}_label').textContent = this.files[0].name"
-      )
-    )
+      def file_field(attribute, **options, &)
+        input = super(
+          attribute,
+          **options.merge(
+            class: :hidden,
+            onchange: "document.getElementById('#{attribute}_label').textContent = this.files[0].name"
+          )
+        )
 
-    render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
-  end
+        render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
+      end
 
-  private
+      private
 
-  def text_input_class
-    'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'
+      def text_input_class
+        'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'
+      end
+    end
   end
 end

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -15,13 +15,7 @@ module Tailwinds
       end
 
       def file_field(attribute, **options, &)
-        input = super(
-          attribute,
-          **options.merge(
-            class: :hidden,
-            onchange: "document.getElementById('#{attribute}_label').textContent = this.files[0].name"
-          )
-        )
+        input = super(attribute, **options.merge(class: :hidden))
 
         render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
       end

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -9,7 +9,10 @@ module Tailwinds
         render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
       end
 
-      alias password_field text_field
+      def password_field(attribute, **options, &)
+        input = super(attribute, **options.merge(class: text_input_class))
+        render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
+      end
 
       def file_field(attribute, **options, &)
         input = super(

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Tailwinds::Form::Builder < Tramway::Views::FormBuilder
+  def text_field(attribute, **options, &)
+    input = super(attribute, **options.merge(class: text_input_class))
+    render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
+  end
+
+  alias password_field text_field
+
+  def file_field(attribute, **options, &)
+    input = super(
+      attribute,
+      **options.merge(
+        class: :hidden,
+        onchange: "document.getElementById('#{attribute}_label').textContent = this.files[0].name"
+      )
+    )
+
+    render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
+  end
+
+  private
+
+  def text_input_class
+    'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'
+  end
+end

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -20,6 +20,10 @@ module Tailwinds
         render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
       end
 
+      def submit(action, **options, &)
+        render(Tailwinds::Form::SubmitButtonComponent.new(action, **options), &)
+      end
+
       private
 
       def text_input_class

--- a/app/components/tailwinds/form/file_field_component.html.haml
+++ b/app/components/tailwinds/form/file_field_component.html.haml
@@ -1,0 +1,4 @@
+.mb-4
+  %label.inline-block.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded.cursor-pointer.mt-4{ for: @for }
+    = @label
+  = @input

--- a/app/components/tailwinds/form/file_field_component.rb
+++ b/app/components/tailwinds/form/file_field_component.rb
@@ -3,7 +3,7 @@
 module Tailwinds
   module Form
     # Tailwind-styled file_field input
-    class FileFieldComponent < ViewComponent::Base
+    class FileFieldComponent < TailwindComponent
       def initialize(input, attribute, object_name: nil, **options)
         @label = options[:label] || attribute.to_s.capitalize
         @for = "#{object_name}_#{attribute}"

--- a/app/components/tailwinds/form/file_field_component.rb
+++ b/app/components/tailwinds/form/file_field_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tailwinds::Form::FileFieldComponent < ViewComponent::Base
+  def initialize(input, attribute, object_name: nil, **options)
+    @label = options[:label] || attribute.to_s.capitalize
+    @for = "#{object_name}_#{attribute}"
+    @input = input
+  end
+end

--- a/app/components/tailwinds/form/file_field_component.rb
+++ b/app/components/tailwinds/form/file_field_component.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-class Tailwinds::Form::FileFieldComponent < ViewComponent::Base
-  def initialize(input, attribute, object_name: nil, **options)
-    @label = options[:label] || attribute.to_s.capitalize
-    @for = "#{object_name}_#{attribute}"
-    @input = input
+module Tailwinds
+  module Form
+    # Tailwind-styled file_field input
+    class FileFieldComponent < ViewComponent::Base
+      def initialize(input, attribute, object_name: nil, **options)
+        @label = options[:label] || attribute.to_s.capitalize
+        @for = "#{object_name}_#{attribute}"
+        @input = input
+      end
+    end
   end
 end

--- a/app/components/tailwinds/form/submit_button_component.html.haml
+++ b/app/components/tailwinds/form/submit_button_component.html.haml
@@ -1,0 +1,4 @@
+.flex.items-center.justify-between
+  %button.bg-red-500.hover:bg-red-700.text-white.font-bold.py-2.px-4.rounded.focus:outline-none.focus:shadow-outline{ type: :submit, name: :commit, **@options }
+    = @text
+  = @content

--- a/app/components/tailwinds/form/submit_button_component.rb
+++ b/app/components/tailwinds/form/submit_button_component.rb
@@ -3,7 +3,7 @@
 module Tailwinds
   module Form
     # Tailwind-styled submit button
-    class SubmitButtonComponent < ViewComponent::Base
+    class SubmitButtonComponent < TailwindComponent
       def initialize(action, **options)
         @options = options.except :type
 

--- a/app/components/tailwinds/form/submit_button_component.rb
+++ b/app/components/tailwinds/form/submit_button_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tailwinds::Form::SubmitButtonComponent < ViewComponent::Base
+  def initialize(action, **options)
+    @options = options.except :type
+
+    @text = action.is_a?(String) ? action : action.to_s.capitalize
+  end
+end

--- a/app/components/tailwinds/form/submit_button_component.rb
+++ b/app/components/tailwinds/form/submit_button_component.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-class Tailwinds::Form::SubmitButtonComponent < ViewComponent::Base
-  def initialize(action, **options)
-    @options = options.except :type
+module Tailwinds
+  module Form
+    # Tailwind-styled submit button
+    class SubmitButtonComponent < ViewComponent::Base
+      def initialize(action, **options)
+        @options = options.except :type
 
-    @text = action.is_a?(String) ? action : action.to_s.capitalize
+        @text = action.is_a?(String) ? action : action.to_s.capitalize
+      end
+    end
   end
 end

--- a/app/components/tailwinds/form/text_field_component.html.haml
+++ b/app/components/tailwinds/form/text_field_component.html.haml
@@ -1,0 +1,4 @@
+.mb-4
+  %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
+    = @label
+  = @input

--- a/app/components/tailwinds/form/text_field_component.rb
+++ b/app/components/tailwinds/form/text_field_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tailwinds::Form::TextFieldComponent < ViewComponent::Base
+  def initialize(input, attribute, object_name: nil, **options)
+    @label = options[:label] || attribute.to_s.humanize
+    @for = "#{object_name}_#{attribute}"
+    @input = input
+  end
+end

--- a/app/components/tailwinds/form/text_field_component.rb
+++ b/app/components/tailwinds/form/text_field_component.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-class Tailwinds::Form::TextFieldComponent < ViewComponent::Base
-  def initialize(input, attribute, object_name: nil, **options)
-    @label = options[:label] || attribute.to_s.humanize
-    @for = "#{object_name}_#{attribute}"
-    @input = input
+module Tailwinds
+  module Form
+    # Tailwind-styled text field
+    class TextFieldComponent < ViewComponent::Base
+      def initialize(input, attribute, object_name: nil, **options)
+        @label = options[:label] || attribute.to_s.humanize
+        @for = "#{object_name}_#{attribute}"
+        @input = input
+      end
+    end
   end
 end

--- a/app/components/tailwinds/form/text_field_component.rb
+++ b/app/components/tailwinds/form/text_field_component.rb
@@ -3,7 +3,7 @@
 module Tailwinds
   module Form
     # Tailwind-styled text field
-    class TextFieldComponent < ViewComponent::Base
+    class TextFieldComponent < TailwindComponent
       def initialize(input, attribute, object_name: nil, **options)
         @label = options[:label] || attribute.to_s.humanize
         @for = "#{object_name}_#{attribute}"

--- a/lib/tramway.rb
+++ b/lib/tramway.rb
@@ -6,7 +6,7 @@ require 'tramway/engine'
 require 'tramway/base_decorator'
 require 'tramway/base_form'
 require 'tramway/config'
-require 'tramway/views'
+require 'tramway/views/form_builder'
 require 'view_component/compiler'
 require 'view_component/engine'
 

--- a/lib/tramway.rb
+++ b/lib/tramway.rb
@@ -6,6 +6,7 @@ require 'tramway/engine'
 require 'tramway/base_decorator'
 require 'tramway/base_form'
 require 'tramway/config'
+require 'tramway/views'
 require 'view_component/compiler'
 require 'view_component/engine'
 

--- a/lib/tramway/engine.rb
+++ b/lib/tramway/engine.rb
@@ -13,6 +13,12 @@ module Tramway
         loaded_class.include Tramway::Helpers::NavbarHelper
       end
 
+      ActiveSupport.on_load(:action_view) do |loaded_class|
+        require 'tramway/helpers/views_helper'
+
+        loaded_class.include Tramway::Helpers::ViewsHelper
+      end
+
       ActiveSupport.on_load(:action_controller) do |loaded_class|
         require 'tramway/helpers/decorate_helper'
 

--- a/lib/tramway/helpers/navbar_helper.rb
+++ b/lib/tramway/helpers/navbar_helper.rb
@@ -4,7 +4,7 @@ require 'tramway/navbar'
 
 module Tramway
   module Helpers
-    # Providing navbar helpers for ActionView
+    # Provides navbar helpers for ActionView
     module NavbarHelper
       def tramway_navbar(**options)
         initialize_navbar

--- a/lib/tramway/helpers/views_helper.rb
+++ b/lib/tramway/helpers/views_helper.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Tramway
   module Helpers
+    # Provides view-oriented helpers for ActionView
     module ViewsHelper
       def tramway_form_for(object, *args, **options, &)
         form_for(object, *args, **options.merge(builder: Tailwinds::Form::Builder), &)

--- a/lib/tramway/helpers/views_helper.rb
+++ b/lib/tramway/helpers/views_helper.rb
@@ -1,0 +1,13 @@
+module Tramway
+  module Helpers
+    module ViewsHelper
+      def tramway_form_for(object, *args, **options, &)
+        form_for(object, *args, **options.merge(builder: Tailwinds::Form::Builder), &)
+      end
+
+      def tailwind_submit_button(action, **options)
+        render Tailwinds::Form::SubmitButtonComponent.new(action, **options)
+      end
+    end
+  end
+end

--- a/lib/tramway/helpers/views_helper.rb
+++ b/lib/tramway/helpers/views_helper.rb
@@ -7,10 +7,6 @@ module Tramway
       def tramway_form_for(object, *args, **options, &)
         form_for(object, *args, **options.merge(builder: Tailwinds::Form::Builder), &)
       end
-
-      def tailwind_submit_button(action, **options)
-        render Tailwinds::Form::SubmitButtonComponent.new(action, **options)
-      end
     end
   end
 end

--- a/lib/tramway/views.rb
+++ b/lib/tramway/views.rb
@@ -1,6 +1,0 @@
-require 'tramway/views/form_builder'
-
-module Tramway
-  module Views
-  end
-end

--- a/lib/tramway/views.rb
+++ b/lib/tramway/views.rb
@@ -1,0 +1,6 @@
+require 'tramway/views/form_builder'
+
+module Tramway
+  module Views
+  end
+end

--- a/lib/tramway/views/form_builder.rb
+++ b/lib/tramway/views/form_builder.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Tramway
+  module Views
+    class FormBuilder < ActionView::Helpers::FormBuilder
+      private
+
+      def render(component, &)
+        component.render_in(@template, &)
+      end
+    end
+  end
+end

--- a/lib/tramway/views/form_builder.rb
+++ b/lib/tramway/views/form_builder.rb
@@ -2,11 +2,14 @@
 
 module Tramway
   module Views
+    # ActionView Form Builder helps us use ViewComponent as form helpers
     class FormBuilder < ActionView::Helpers::FormBuilder
+      attr_reader :template
+
       private
 
       def render(component, &)
-        component.render_in(@template, &)
+        component.render_in(template, &)
       end
     end
   end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Tailwinds::Form::Builder, type: :view do
+  describe '#text_field' do
+    let(:resource)  { build :user }
+    let(:builder) { Tailwinds::Form::Builder.new :user, resource, view, {} }
+    let(:output) do
+      builder.text_field :email
+    end
+
+    it do
+      expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
+      expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
+    end
+  end
+end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -37,4 +37,16 @@ describe Tailwinds::Form::Builder, type: :view do
       expect(output).to have_selector 'label.inline-block.bg-blue-500.text-white.font-bold.py-2.px-4.rounded'
     end
   end
+
+  describe '#submit' do
+    let(:output) do
+      builder.submit 'Create'
+    end
+
+    it do
+      within 'div.flex.items-center.justify-between' do
+        expect(output).to have_selector('button.bg-red-500.text-white')
+      end
+    end
+  end
 end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -35,9 +35,6 @@ describe Tailwinds::Form::Builder, type: :view do
 
     it do
       expect(output).to have_selector 'label.inline-block.bg-blue-500.text-white.font-bold.py-2.px-4.rounded'
-      expect(output).to have_selector(
-        "input[onchange=\"document.getElementById(\'file_label\').textContent = this.files[0].name\"]"
-      )
     end
   end
 end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 describe Tailwinds::Form::Builder, type: :view do
+  let(:resource)  { build :user }
+  let(:builder) { Tailwinds::Form::Builder.new :user, resource, view, {} }
+
   describe '#text_field' do
-    let(:resource)  { build :user }
-    let(:builder) { Tailwinds::Form::Builder.new :user, resource, view, {} }
     let(:output) do
       builder.text_field :email
     end
@@ -13,6 +14,30 @@ describe Tailwinds::Form::Builder, type: :view do
     it do
       expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
       expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
+    end
+  end
+
+  describe '#password_field' do
+    let(:output) do
+      builder.password_field :password
+    end
+
+    it do
+      expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
+      expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
+    end
+  end
+
+  describe '#file_field' do
+    let(:output) do
+      builder.file_field :file
+    end
+
+    it do
+      expect(output).to have_selector 'label.inline-block.bg-blue-500.text-white.font-bold.py-2.px-4.rounded'
+      expect(output).to have_selector(
+        "input[onchange=\"document.getElementById(\'file_label\').textContent = this.files[0].name\"]"
+      )
     end
   end
 end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'support/view_helpers'
 
 describe Tailwinds::Form::Builder, type: :view do
   let(:resource)  { build :user }

--- a/spec/components/tailwinds/nav/item_component_spec.rb
+++ b/spec/components/tailwinds/nav/item_component_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Tailwinds::Nav::ItemComponent, type: :component do
   it 'renders link' do
     render_inline(described_class.new(href: '/test_page')) { 'Sign In' }

--- a/spec/components/tailwinds/navbar_component_spec.rb
+++ b/spec/components/tailwinds/navbar_component_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Tailwinds::NavbarComponent, type: :component do
   context 'with title checks' do
     it 'renders title' do

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Tramway::BaseDecorator do
   let(:object) { double('object') }
   let(:decorator) { Tramway::BaseDecorator }

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -2,4 +2,5 @@
 
 # Test model
 class User < ApplicationRecord
+  attr_reader :password, :file
 end

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -3,5 +3,7 @@
 # Load the Rails application.
 require_relative 'application'
 
+require 'view_component'
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe Tramway::BaseForm do
   context 'with persisted object' do
     let(:object) { create :user }

--- a/spec/helpers/decorate_helper_spec.rb
+++ b/spec/helpers/decorate_helper_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Tramway::Helpers::DecorateHelper, type: :controller do
   let(:controller) { ActionController::Base.new }
 

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Tramway::Helpers::FormHelper, type: :helper do
   let(:dummy_class) do
     Class.new do

--- a/spec/helpers/navbar_helper_spec.rb
+++ b/spec/helpers/navbar_helper_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
 require 'support/view_helpers'
 require 'helpers/navbar/shared_examples'
 

--- a/spec/helpers/views_helper_spec.rb
+++ b/spec/helpers/views_helper_spec.rb
@@ -11,19 +11,18 @@ describe Tramway::Helpers::ViewsHelper, type: :view do
   describe '#tramway_form_for' do
     it 'calls form_for with the correct builder' do
       object = double('Model')
-      expect(view).to receive(:form_for).with(object, anything, hash_including(builder: Tailwinds::Form::Builder))
+      expect(view).to receive(:form_for).with(object, hash_including(builder: Tailwinds::Form::Builder))
 
       view.tramway_form_for(object)
     end
 
     it 'forwards arguments and options to form_for' do
       object = double('Model')
-      args = %i[arg1 arg2]
       options = { key: 'value' }
 
-      expect(view).to receive(:form_for).with(object, *args, hash_including(options))
+      expect(view).to receive(:form_for).with(object, hash_including(options))
 
-      view.tramway_form_for(object, *args, options)
+      view.tramway_form_for(object, **options)
     end
   end
 
@@ -34,18 +33,7 @@ describe Tramway::Helpers::ViewsHelper, type: :view do
 
       expect(view).to receive(:render).with(an_instance_of(Tailwinds::Form::SubmitButtonComponent))
 
-      view.tailwind_submit_button(action, options)
-    end
-
-    it 'forwards action and options to the SubmitButtonComponent' do
-      action = 'Submit'
-      options = { class: 'custom-class', data: { key: 'value' } }
-
-      expect(view).to receive(:render).with(an_instance_of(Tailwinds::Form::SubmitButtonComponent).and(
-                                              have_attributes(action:, options:)
-                                            ))
-
-      view.tailwind_submit_button(action, options)
+      view.tailwind_submit_button(action, **options)
     end
   end
 end

--- a/spec/helpers/views_helper_spec.rb
+++ b/spec/helpers/views_helper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'support/view_helpers'
+
+describe Tramway::Helpers::ViewsHelper, type: :view do
+  before do
+    described_class.include ViewHelpers
+    view.extend described_class
+  end
+
+  describe '#tramway_form_for' do
+    it 'calls form_for with the correct builder' do
+      object = double('Model')
+      expect(view).to receive(:form_for).with(object, anything, hash_including(builder: Tailwinds::Form::Builder))
+
+      view.tramway_form_for(object)
+    end
+
+    it 'forwards arguments and options to form_for' do
+      object = double('Model')
+      args = %i[arg1 arg2]
+      options = { key: 'value' }
+
+      expect(view).to receive(:form_for).with(object, *args, hash_including(options))
+
+      view.tramway_form_for(object, *args, options)
+    end
+  end
+
+  describe '#tailwind_submit_button' do
+    it 'renders a Tailwinds::Form::SubmitButtonComponent' do
+      action = 'Submit'
+      options = { class: 'custom-class' }
+
+      expect(view).to receive(:render).with(an_instance_of(Tailwinds::Form::SubmitButtonComponent))
+
+      view.tailwind_submit_button(action, options)
+    end
+
+    it 'forwards action and options to the SubmitButtonComponent' do
+      action = 'Submit'
+      options = { class: 'custom-class', data: { key: 'value' } }
+
+      expect(view).to receive(:render).with(an_instance_of(Tailwinds::Form::SubmitButtonComponent).and(
+                                              have_attributes(action:, options:)
+                                            ))
+
+      view.tailwind_submit_button(action, options)
+    end
+  end
+end

--- a/spec/helpers/views_helper_spec.rb
+++ b/spec/helpers/views_helper_spec.rb
@@ -25,15 +25,4 @@ describe Tramway::Helpers::ViewsHelper, type: :view do
       view.tramway_form_for(object, **options)
     end
   end
-
-  describe '#tailwind_submit_button' do
-    it 'renders a Tailwinds::Form::SubmitButtonComponent' do
-      action = 'Submit'
-      options = { class: 'custom-class' }
-
-      expect(view).to receive(:render).with(an_instance_of(Tailwinds::Form::SubmitButtonComponent))
-
-      view.tailwind_submit_button(action, **options)
-    end
-  end
 end

--- a/spec/tramway/config_spec.rb
+++ b/spec/tramway/config_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Tramway::Config do
   let(:config) { Tramway::Config.instance }
 

--- a/spec/tramway/configs/entities/route_spec.rb
+++ b/spec/tramway/configs/entities/route_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# spec/route_spec.rb
-require 'spec_helper'
 require 'tramway/configs/entities/route' # Adjust the path to the Route class
 
 RSpec.describe Tramway::Configs::Entities::Route do

--- a/spec/tramway/configs/entity_spec.rb
+++ b/spec/tramway/configs/entity_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 shared_examples 'Tramway Config Entity human_name' do |name|
   subject { described_class.new(name:) }
 


### PR DESCRIPTION
## What's changed basically?

Now we have 2 more helpers
* `tramway_form_for` that renders Tailwind-styled form by default

## What's changed for tramway drivers?

### Before

```ruby
= form_for object, :resource, builder: SomeBuilderThatProvidesTailwindStyles do |f|
  -# code
  = submit_button class: 'a.lot.of.tailwind.classes.here'
```

### After

We have Tailwind-styled form helpers 

```ruby
= tramway_form_for object, :resource do |f|
  = f.text_field :text
  = f.password_field :password
  = f.file_field :file
  = f.submit 'Create'
```

Find more info [here](https://github.com/Purple-Magic/tramway/tree/tailwind_form_builder#tailwind-styled-forms)

PR will be merged on October, 28