### PR TITLE
Tramway Form. Fix saving non-existing attributes

### DIFF
--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -65,7 +65,7 @@ module Tramway
 
     def __submit(params)
       self.class.properties.each do |attribute|
-        public_send("#{attribute}=", params[attribute])
+        public_send("#{attribute}=", params[attribute]) if params.keys.include? attribute.to_s
       end
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_627_061_428) do
+ActiveRecord::Schema[7.1].define(version: 20_230_627_061_428) do
   create_table 'users', force: :cascade do |t|
     t.string 'email', default: '', null: false
     t.string 'encrypted_password', default: '', null: false

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -84,4 +84,24 @@ RSpec.describe Tramway::BaseForm do
       end
     end
   end
+
+  context 'with non-existing attributes' do
+    let(:object) { create :user, email: 'asya@purple-magic.com' }
+    subject { described_class.new(object) }
+
+    describe '#submit' do
+      let(:params) { { password: '123456' } }
+
+      it 'does not update non-existing attributes' do
+        expect(object).to receive(:save).and_return(true)
+        expect(object).to receive(:reload)
+
+        previous_email = object.email
+
+        subject.submit(params)
+
+        expect(object.email).to eq previous_email
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What's Changed, in General?

- Improved handling of non-existent attributes during saving.

## What's Changed for Tramway Drivers?

### Before the Change

```ruby
class UserForm < Tramway::BaseForm
  properties :email, :name
end

# Assuming params = { email: 'asya@purple-magic.com' }
# Note: `first_name` is not included in the `params`

user_form = UserForm.new user
user_form.submit params

user.reload
user.first_name # Returns nil

# The issue: `first_name` gets updated even though it's not present in `params`
```

### After the Change

- `first_name` will no longer be updated if it is not included in the `params`.