### PR TITLE
Decorating nil object

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ def show
 end
 ```
 
+#### Decorate nil
+
+Tramway Decorator does not decorate nil objects
+
+```ruby
+user = nil
+UserDecorator.decorate user # => nil
+```
+
 ### Tramway Form
 
 Tramway provides **convenient** form objects for Rails applications. List properties you want to change and the rules in Form classes. No controllers overloading.

--- a/lib/tramway/base_decorator.rb
+++ b/lib/tramway/base_decorator.rb
@@ -17,7 +17,10 @@ module Tramway
     end
 
     class << self
+      # :reek:NilCheck { enabled: false } because checking for nil is not a type-checking issue but business logic
       def decorate(object_or_array)
+        return if object_or_array.nil?
+
         if Tramway::Decorators::CollectionDecorators.collection?(object_or_array)
           Tramway::Decorators::CollectionDecorators.decorate_collection(
             collection: object_or_array,

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe Tramway::BaseDecorator do
         described_class.decorate(object)
       end
     end
+
+    context 'when object is nil' do
+      let(:object) { nil }
+
+      it 'returns nil' do
+        expect(described_class.decorate(object)).to be_nil
+      end
+    end
   end
 
   describe '.delegate_attributes' do


### PR DESCRIPTION
# Discussion

What should we do with `nil`-object decorating? There are 3 approaches:
1. Return just `nil`
2. Decorate nil object
3. Raise error

I've implemented the first approach here. Waiting for your opinion :slightly_smiling_face: 

## What's changed for tramway drivers?

### Before

```ruby
user = nil
UserDecorator.decorate user # => UserDecorator#object
```

### After

```ruby
user = nil
UserDecorator.decorate user # => nil
```

