### PR TITLE
Tailwind styled select

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2']
+        ruby: ['3.2', '3.3']
 
     runs-on: ubuntu-latest
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,7 @@ gem 'sprockets-rails'
 
 gem 'haml-rails'
 
-# Start debugger with binding.b [https://github.com/ruby/debug]
-# gem "debug", ">= 1.0.0"
+gem 'dry-initializer'
 
 group :development do
   gem 'reek'

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Tramway provides `tramway_form_for` helper that renders Tailwind-styled forms by
 = tramway_form_for User.new do |f|
   = f.text_field :text
   = f.password_field :password
+  = f.select :role, [:admin, :user]
   = f.file_field :file
   = f.submit "Create User"
 ```
@@ -344,6 +345,7 @@ Available form helpers:
 * text_field
 * password_field
 * file_field
+* select
 * submit
 
 ## Contributing

--- a/app/components/tailwind_component.rb
+++ b/app/components/tailwind_component.rb
@@ -4,4 +4,12 @@ require 'view_component'
 
 # Base TailwindComponent. Contains base features for all tailwind components
 class TailwindComponent < ViewComponent::Base
+  extend Dry::Initializer[undefined: false]
+
+  option :template
+  option :attribute
+  option :object_name
+  option :options
+  option :label
+  option :for
 end

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -3,21 +3,51 @@
 module Tailwinds
   module Form
     # Provides Tailwind-styled forms
+    # :reek:InstanceVariableAssumption
     class Builder < Tramway::Views::FormBuilder
       def text_field(attribute, **options, &)
-        input = super(attribute, **options.merge(class: text_input_class))
-        render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
+        render(Tailwinds::Form::TextFieldComponent.new(
+                 template: @template,
+                 attribute:,
+                 object_name:,
+                 label: label(options, attribute),
+                 for: for_id(attribute),
+                 options:
+               ), &)
       end
 
       def password_field(attribute, **options, &)
-        input = super(attribute, **options.merge(class: text_input_class))
-        render(Tailwinds::Form::TextFieldComponent.new(input, attribute, object_name:, **options), &)
+        render(Tailwinds::Form::TextFieldComponent.new(
+                 template: @template,
+                 attribute:,
+                 object_name:,
+                 label: label(options, attribute),
+                 for: for_id(attribute),
+                 options:
+               ), &)
       end
 
       def file_field(attribute, **options, &)
-        input = super(attribute, **options.merge(class: :hidden))
+        render(Tailwinds::Form::FileFieldComponent.new(
+                 template: @template,
+                 attribute:,
+                 object_name:,
+                 label: label(options, attribute),
+                 for: for_id(attribute),
+                 options:
+               ), &)
+      end
 
-        render(Tailwinds::Form::FileFieldComponent.new(input, attribute, object_name:, **options), &)
+      def select(attribute, collection, **options, &)
+        render(Tailwinds::Form::SelectComponent.new(
+                 template: @template,
+                 attribute:,
+                 collection:,
+                 object_name:,
+                 label: label(options, attribute),
+                 for: for_id(attribute),
+                 options:
+               ), &)
       end
 
       def submit(action, **options, &)
@@ -26,8 +56,13 @@ module Tailwinds
 
       private
 
-      def text_input_class
-        'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'
+      # :reek:UtilityFunction
+      def label(options, attribute)
+        options[:label] || attribute.to_s.humanize
+      end
+
+      def for_id(attribute)
+        "#{object_name}_#{attribute}"
       end
     end
   end

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -6,48 +6,19 @@ module Tailwinds
     # :reek:InstanceVariableAssumption
     class Builder < Tramway::Views::FormBuilder
       def text_field(attribute, **options, &)
-        render(Tailwinds::Form::TextFieldComponent.new(
-                 template: @template,
-                 attribute:,
-                 object_name:,
-                 label: label(options, attribute),
-                 for: for_id(attribute),
-                 options:
-               ), &)
+        render(Tailwinds::Form::TextFieldComponent.new(**default_options(attribute, options)), &)
       end
 
       def password_field(attribute, **options, &)
-        render(Tailwinds::Form::TextFieldComponent.new(
-                 template: @template,
-                 attribute:,
-                 object_name:,
-                 label: label(options, attribute),
-                 for: for_id(attribute),
-                 options:
-               ), &)
+        render(Tailwinds::Form::TextFieldComponent.new(**default_options(attribute, options)), &)
       end
 
       def file_field(attribute, **options, &)
-        render(Tailwinds::Form::FileFieldComponent.new(
-                 template: @template,
-                 attribute:,
-                 object_name:,
-                 label: label(options, attribute),
-                 for: for_id(attribute),
-                 options:
-               ), &)
+        render(Tailwinds::Form::FileFieldComponent.new(**default_options(attribute, options)), &)
       end
 
       def select(attribute, collection, **options, &)
-        render(Tailwinds::Form::SelectComponent.new(
-                 template: @template,
-                 attribute:,
-                 collection:,
-                 object_name:,
-                 label: label(options, attribute),
-                 for: for_id(attribute),
-                 options:
-               ), &)
+        render(Tailwinds::Form::SelectComponent.new(**default_options(attribute, options).merge(collection:)), &)
       end
 
       def submit(action, **options, &)
@@ -56,8 +27,19 @@ module Tailwinds
 
       private
 
+      def default_options(attribute, options)
+        {
+          template: @template,
+          attribute:,
+          object_name:,
+          label: label(attribute, options),
+          for: for_id(attribute),
+          options:
+        }
+      end
+
       # :reek:UtilityFunction
-      def label(options, attribute)
+      def label(attribute, options)
         options[:label] || attribute.to_s.humanize
       end
 

--- a/app/components/tailwinds/form/file_field_component.html.haml
+++ b/app/components/tailwinds/form/file_field_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.inline-block.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded.cursor-pointer.mt-4{ for: @for }
     = @label
-  = @input
+  = @template.file_field @object_name, @attribute

--- a/app/components/tailwinds/form/file_field_component.rb
+++ b/app/components/tailwinds/form/file_field_component.rb
@@ -4,11 +4,6 @@ module Tailwinds
   module Form
     # Tailwind-styled file_field input
     class FileFieldComponent < TailwindComponent
-      def initialize(input, attribute, object_name: nil, **options)
-        @label = options[:label] || attribute.to_s.capitalize
-        @for = "#{object_name}_#{attribute}"
-        @input = input
-      end
     end
   end
 end

--- a/app/components/tailwinds/form/select_component.html.haml
+++ b/app/components/tailwinds/form/select_component.html.haml
@@ -1,0 +1,4 @@
+.mb-4
+  %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
+    = @label
+  = @template.select @object_name, @attribute, @collection, {}, @options.merge(class: 'bg-white border border-gray-300 text-gray-700 py-2 px-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent')

--- a/app/components/tailwinds/form/select_component.rb
+++ b/app/components/tailwinds/form/select_component.rb
@@ -3,7 +3,8 @@
 module Tailwinds
   module Form
     # Tailwind-styled text field
-    class TextFieldComponent < TailwindComponent
+    class SelectComponent < TailwindComponent
+      option :collection
     end
   end
 end

--- a/app/components/tailwinds/form/text_field_component.html.haml
+++ b/app/components/tailwinds/form/text_field_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
     = @label
-  = @input
+  = @template.text_field @object_name, @attribute, **@options.merge(class: 'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500')

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -49,4 +49,17 @@ describe Tailwinds::Form::Builder, type: :view do
       end
     end
   end
+
+  describe '#select' do
+    let(:output) do
+      builder.select :role, %i[admin user]
+    end
+
+    it do
+      expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
+      expect(output).to have_selector 'select.bg-white.border.border-gray-300.text-gray-700.py-2.px-2.rounded-lg'
+      expect(output).to have_selector 'option[value="admin"]'
+      expect(output).to have_selector 'option[value="user"]'
+    end
+  end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -2,5 +2,5 @@
 
 # Test model
 class User < ApplicationRecord
-  attr_reader :password, :file
+  attr_reader :password, :file, :role
 end


### PR DESCRIPTION
## What's changed basically?

Added `select` to Tailwind-styled form

## What's changed for tramway drivers?

### Before

```ruby
= tramway_form_for object, :resource do |f|
  = f.select attribute, []
```

returned default select

### After

It returns tailwind-styled select tag.

- [x] Added `select` method to FormBuilder
- [x] Rewritten all Tailwind ViewComponents using DryInitializer
