### PR TITLE
Decorates all descendants of ActiveRecord::Relation class

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,27 @@ class UserDecorator < Tramway::BaseDecorator
 end
 ```
 
-#### Decorate single object
+#### Decorate a single object
 
 You can use the same method to decorate a single object either
 
 ```ruby
 def show
   @user = tramway_decorate User.find params[:id]
+end
+```
+
+#### Decorate a collection of objects
+
+```ruby
+def index
+  @users = tramway_decorate User.all
+end
+```
+
+```ruby
+def index
+  @posts = tramway_decorate user.posts
 end
 ```
 

--- a/lib/tramway/decorators/collection_decorator.rb
+++ b/lib/tramway/decorators/collection_decorator.rb
@@ -14,7 +14,7 @@ module Tramway
       end
 
       def collection?(object)
-        object.class.name.in? ['ActiveRecord::Relation', 'Array']
+        object.is_a?(Array) || object.is_a?(ActiveRecord::Relation)
       end
     end
   end

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+shared_examples 'Decorate Collection' do
+  it 'calls decorate_collection with the collection' do
+    expect(Tramway::Decorators::CollectionDecorators).to receive(:decorate_collection)
+      .with(collection: relation, decorator:)
+    described_class.decorate(relation)
+  end
+end
+
 RSpec.describe Tramway::BaseDecorator do
   let(:object) { double('object') }
   let(:decorator) { Tramway::BaseDecorator }
@@ -27,11 +35,7 @@ RSpec.describe Tramway::BaseDecorator do
         User.all
       end
 
-      it 'calls decorate_collection with the collection' do
-        expect(Tramway::Decorators::CollectionDecorators).to receive(:decorate_collection)
-          .with(collection: relation, decorator:)
-        described_class.decorate(relation)
-      end
+      include_examples 'Decorate Collection'
     end
 
     context 'when object_or_array is an Array' do
@@ -40,11 +44,31 @@ RSpec.describe Tramway::BaseDecorator do
         User.all.to_a
       end
 
-      it 'calls decorate_collection with the collection' do
-        expect(Tramway::Decorators::CollectionDecorators).to receive(:decorate_collection)
-          .with(collection: relation, decorator:)
-        described_class.decorate(relation)
+      include_examples 'Decorate Collection'
+    end
+
+    context 'when object_or_array is an ActiveRecord::Relation by association' do
+      let(:relation) do
+        user = create :user
+        create_list(:post, 5, user:)
+
+        user.reload
+        user.posts
       end
+
+      include_examples 'Decorate Collection'
+    end
+
+    context 'when object_or_array is an ActiveRecord::AssociationRelation' do
+      let(:relation) do
+        user = create :user
+        create_list(:post, 5, user:)
+
+        user.reload
+        user.posts.order(id: :asc)
+      end
+
+      include_examples 'Decorate Collection'
     end
 
     context 'when object_or_array is not an ActiveRecord::Relation' do

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Test model
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -2,5 +2,7 @@
 
 # Test model
 class User < ApplicationRecord
+  has_many :posts
+
   attr_reader :password, :file
 end

--- a/spec/dummy/db/migrate/20240103082421_create_posts.rb
+++ b/spec/dummy/db/migrate/20240103082421_create_posts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.integer :user_id
+      t.string :title
+      t.string :text
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -12,7 +12,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_230_627_061_428) do
+ActiveRecord::Schema[7.1].define(version: 20_240_103_082_421) do
+  create_table 'posts', force: :cascade do |t|
+    t.integer 'user_id'
+    t.string 'title'
+    t.string 'text'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+  end
+
   create_table 'users', force: :cascade do |t|
     t.string 'email', default: '', null: false
     t.string 'encrypted_password', default: '', null: false

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user
+  factory :post
 end


### PR DESCRIPTION
## What's changed basically?

Decorating all descendants of `ActiveRecord::Relation` class

## What's changed for tramway drivers?

### Before

```ruby
tramway_decorate user.posts
```

returned the error `There is no Post::ActiveRecord_Associations_CollectionProxyDecorator` class 

**AND**

```ruby
tramway_decorate user.posts.order(id: :desc)
```

returned the error `There is no Post::ActiveRecord_AssociationRelationDecorator` class 

### After

```ruby
tramway_decorate user.posts
```
**AND**

```ruby
tramway_decorate user.posts.order(id: :desc)
```

both return an array of `PostDecorator` objects.
