### PR TITLE
Delegate ID to Tramway Form

### DIFF
--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -6,7 +6,7 @@ module Tramway
   class BaseForm
     attr_reader :object
 
-    %i[model_name to_key to_model errors attributes].each do |method_name|
+    %i[id model_name to_key to_model errors attributes].each do |method_name|
       delegate method_name, to: :object
     end
 

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -6,12 +6,14 @@ module Tramway
   class BaseForm
     attr_reader :object
 
-    %i[id model_name to_key to_model errors attributes].each do |method_name|
+    %i[model_name to_key to_model errors attributes].each do |method_name|
       delegate method_name, to: :object
     end
 
     def initialize(object)
       @object = object
+
+      self.class.delegate object.class.primary_key, to: :object
     end
 
     class << self

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Tramway::BaseForm do
 
     context 'method delegation' do
       it 'delegates certain methods to the object' do
-        methods_to_delegate = %i[model_name to_key to_model errors attributes]
+        methods_to_delegate = %i[id model_name to_key to_model errors attributes]
 
         methods_to_delegate.each do |method|
           expect(object).to receive(method)


### PR DESCRIPTION
## What's changed basically?

Delegating `id` attribute to Tramway Form by default

## What's changed for tramway drivers?

### Before

```ruby
@user_form = tramway_form User.find(params[:id])
@user_form.id # returns "NoMethodError `id`"
```

### After

```ruby
@user_form = tramway_form User.find(params[:id])
@user_form.id # returns user-id
```