### PR TITLE
BUGFIX: Return previous implementation for file input

### DIFF
--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -14,7 +14,9 @@ module Tailwinds
       end
 
       def file_field(attribute, **options, &)
-        render(Tailwinds::Form::FileFieldComponent.new(**default_options(attribute, options)), &)
+        input = super(attribute, **options.merge(class: :hidden))
+
+        render(Tailwinds::Form::FileFieldComponent.new(input:, **default_options(attribute, options)), &)
       end
 
       def select(attribute, collection, **options, &)

--- a/app/components/tailwinds/form/file_field_component.html.haml
+++ b/app/components/tailwinds/form/file_field_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.inline-block.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded.cursor-pointer.mt-4{ for: @for }
     = @label
-  = @template.file_field @object_name, @attribute
+  = @input

--- a/app/components/tailwinds/form/file_field_component.rb
+++ b/app/components/tailwinds/form/file_field_component.rb
@@ -4,6 +4,7 @@ module Tailwinds
   module Form
     # Tailwind-styled file_field input
     class FileFieldComponent < TailwindComponent
+      option :input
     end
   end
 end


### PR DESCRIPTION
## What's changed basically?

Bug fix of file input. According to the implementation [file_field](https://apidock.com/rails/v6.0.0/ActionView/Helpers/FormHelper/file_field) method. It needs to be run from `form_object`, so we need to run `super` method inside of `FormBuilder`.