### PR TITLE
Use values in forms

### DIFF
--- a/app/components/tailwind_component.rb
+++ b/app/components/tailwind_component.rb
@@ -6,10 +6,9 @@ require 'view_component'
 class TailwindComponent < ViewComponent::Base
   extend Dry::Initializer[undefined: false]
 
-  option :template
+  option :input
   option :attribute
   option :value, optional: true
-  option :object_name
   option :options
   option :label
   option :for

--- a/app/components/tailwind_component.rb
+++ b/app/components/tailwind_component.rb
@@ -8,6 +8,7 @@ class TailwindComponent < ViewComponent::Base
 
   option :template
   option :attribute
+  option :value, optional: true
   option :object_name
   option :options
   option :label

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -16,7 +16,7 @@ module Tailwinds
       def file_field(attribute, **options, &)
         input = super(attribute, **options.merge(class: :hidden))
 
-        render(Tailwinds::Form::FileFieldComponent.new(input:, **default_options(attribute, options)), &)
+        render(Tailwinds::Form::FileFieldComponent.new(input:, **default_options(attribute, options).except(:value)), &)
       end
 
       def select(attribute, collection, **options, &)
@@ -36,7 +36,8 @@ module Tailwinds
           object_name:,
           label: label(attribute, options),
           for: for_id(attribute),
-          options:
+          options:,
+          value: object.public_send(attribute)
         }
       end
 

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -42,7 +42,7 @@ module Tailwinds
       private
 
       def input(method_name)
-        unbound_method = Tramway::Views::FormBuilder.instance_method(method_name)
+        unbound_method = self.class.superclass.instance_method(method_name)
         unbound_method.bind(self)
       end
 

--- a/app/components/tailwinds/form/builder.rb
+++ b/app/components/tailwinds/form/builder.rb
@@ -6,21 +6,33 @@ module Tailwinds
     # :reek:InstanceVariableAssumption
     class Builder < Tramway::Views::FormBuilder
       def text_field(attribute, **options, &)
-        render(Tailwinds::Form::TextFieldComponent.new(**default_options(attribute, options)), &)
+        render(Tailwinds::Form::TextFieldComponent.new(
+                 input: input(:text_field),
+                 value: get_value(attribute, options),
+                 **default_options(attribute, options)
+               ), &)
       end
 
       def password_field(attribute, **options, &)
-        render(Tailwinds::Form::TextFieldComponent.new(**default_options(attribute, options)), &)
+        render(Tailwinds::Form::TextFieldComponent.new(
+                 input: input(:password_field),
+                 **default_options(attribute, options)
+               ), &)
       end
 
       def file_field(attribute, **options, &)
         input = super(attribute, **options.merge(class: :hidden))
 
-        render(Tailwinds::Form::FileFieldComponent.new(input:, **default_options(attribute, options).except(:value)), &)
+        render(Tailwinds::Form::FileFieldComponent.new(input:, **default_options(attribute, options)), &)
       end
 
       def select(attribute, collection, **options, &)
-        render(Tailwinds::Form::SelectComponent.new(**default_options(attribute, options).merge(collection:)), &)
+        render(Tailwinds::Form::SelectComponent.new(
+                 input: input(:select),
+                 value: options[:selected] || object.public_send(attribute),
+                 collection:,
+                 **default_options(attribute, options)
+               ), &)
       end
 
       def submit(action, **options, &)
@@ -29,15 +41,21 @@ module Tailwinds
 
       private
 
+      def input(method_name)
+        unbound_method = Tramway::Views::FormBuilder.instance_method(method_name)
+        unbound_method.bind(self)
+      end
+
+      def get_value(attribute, options)
+        options[:value] || object.public_send(attribute)
+      end
+
       def default_options(attribute, options)
         {
-          template: @template,
           attribute:,
-          object_name:,
           label: label(attribute, options),
           for: for_id(attribute),
-          options:,
-          value: object.public_send(attribute)
+          options:
         }
       end
 

--- a/app/components/tailwinds/form/select_component.html.haml
+++ b/app/components/tailwinds/form/select_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
     = @label
-  = @template.select @object_name, @attribute, @collection, {}, @options.merge(class: 'bg-white border border-gray-300 text-gray-700 py-2 px-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent'), selected: @value
+  = @input.call(@attribute, @collection, { selected: @value }, @options.merge(class: 'bg-white border border-gray-300 text-gray-700 py-2 px-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent'))

--- a/app/components/tailwinds/form/select_component.html.haml
+++ b/app/components/tailwinds/form/select_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
     = @label
-  = @template.select @object_name, @attribute, @collection, {}, @options.merge(class: 'bg-white border border-gray-300 text-gray-700 py-2 px-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent')
+  = @template.select @object_name, @attribute, @collection, {}, @options.merge(class: 'bg-white border border-gray-300 text-gray-700 py-2 px-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent'), selected: @value

--- a/app/components/tailwinds/form/text_field_component.html.haml
+++ b/app/components/tailwinds/form/text_field_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
     = @label
-  = @template.text_field @object_name, @attribute, **@options.merge(class: 'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500')
+  = @template.text_field @object_name, @attribute, **@options.merge(class: 'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'), value: @value

--- a/app/components/tailwinds/form/text_field_component.html.haml
+++ b/app/components/tailwinds/form/text_field_component.html.haml
@@ -1,4 +1,4 @@
 .mb-4
   %label.block.text-gray-700.text-sm.font-bold.mb-2{ for: @for }
     = @label
-  = @template.text_field @object_name, @attribute, **@options.merge(class: 'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'), value: @value
+  = @input.call @attribute, **@options.merge(class: 'w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-red-500'), value: @value

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -27,6 +27,7 @@ describe Tailwinds::Form::Builder, type: :view do
 
     context 'with value from object' do
       before { resource.email = email }
+
       let(:email) { 'leopold@purple-magic.com' }
       let(:output) { builder.text_field :email }
 

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -10,7 +10,7 @@ describe Tailwinds::Form::Builder, type: :view do
     context 'default' do
       let(:output) { builder.text_field :email }
 
-      it do
+      it 'gets default value' do
         expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
         expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
       end
@@ -74,7 +74,7 @@ describe Tailwinds::Form::Builder, type: :view do
     context 'default' do
       let(:output) { builder.select :role, %i[admin user] }
 
-      it do
+      it 'behaves as usual' do
         expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
         expect(output).to have_selector 'select.bg-white.border.border-gray-300.text-gray-700.py-2.px-2.rounded-lg'
         expect(output).to have_selector 'option[value="admin"]'
@@ -86,7 +86,7 @@ describe Tailwinds::Form::Builder, type: :view do
       let(:selected) { :admin }
       let(:output) { builder.select :role, %i[admin user], selected: }
 
-      it do
+      it 'gets value from options' do
         expect(output).to have_selector 'option[value="admin"][selected]'
       end
     end
@@ -95,7 +95,7 @@ describe Tailwinds::Form::Builder, type: :view do
       before { resource.role = :admin }
       let(:output) { builder.select :role, %i[admin user] }
 
-      it do
+      it 'gets value from object' do
         expect(output).to have_selector 'option[value="admin"][selected]'
       end
     end

--- a/spec/components/tailwinds/form/builder_spec.rb
+++ b/spec/components/tailwinds/form/builder_spec.rb
@@ -7,13 +7,32 @@ describe Tailwinds::Form::Builder, type: :view do
   let(:builder) { Tailwinds::Form::Builder.new :user, resource, view, {} }
 
   describe '#text_field' do
-    let(:output) do
-      builder.text_field :email
+    context 'default' do
+      let(:output) { builder.text_field :email }
+
+      it do
+        expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
+        expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
+      end
     end
 
-    it do
-      expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
-      expect(output).to have_selector 'input.w-full.px-3.py-2.border.border-gray-300.rounded'
+    context 'with value from options' do
+      let(:value) { 'leopold@purple-magic.com' }
+      let(:output) { builder.text_field :email, value: }
+
+      it 'gets value from options' do
+        expect(output).to have_selector "input[value='#{value}']"
+      end
+    end
+
+    context 'with value from object' do
+      before { resource.email = email }
+      let(:email) { 'leopold@purple-magic.com' }
+      let(:output) { builder.text_field :email }
+
+      it 'gets value from object' do
+        expect(output).to have_selector "input[value='#{email}']"
+      end
     end
   end
 
@@ -51,15 +70,33 @@ describe Tailwinds::Form::Builder, type: :view do
   end
 
   describe '#select' do
-    let(:output) do
-      builder.select :role, %i[admin user]
+    context 'default' do
+      let(:output) { builder.select :role, %i[admin user] }
+
+      it do
+        expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
+        expect(output).to have_selector 'select.bg-white.border.border-gray-300.text-gray-700.py-2.px-2.rounded-lg'
+        expect(output).to have_selector 'option[value="admin"]'
+        expect(output).to have_selector 'option[value="user"]'
+      end
     end
 
-    it do
-      expect(output).to have_selector 'label.block.text-gray-700.text-sm.font-bold.mb-2'
-      expect(output).to have_selector 'select.bg-white.border.border-gray-300.text-gray-700.py-2.px-2.rounded-lg'
-      expect(output).to have_selector 'option[value="admin"]'
-      expect(output).to have_selector 'option[value="user"]'
+    context 'with value from options' do
+      let(:selected) { :admin }
+      let(:output) { builder.select :role, %i[admin user], selected: }
+
+      it do
+        expect(output).to have_selector 'option[value="admin"][selected]'
+      end
+    end
+
+    context 'with value from object' do
+      before { resource.role = :admin }
+      let(:output) { builder.select :role, %i[admin user] }
+
+      it do
+        expect(output).to have_selector 'option[value="admin"][selected]'
+      end
     end
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -4,5 +4,7 @@
 class User < ApplicationRecord
   has_many :posts
 
-  attr_reader :password, :file, :role
+  attr_reader :password, :file
+  # :reek:Attribute { enabled: false }
+  attr_accessor :role
 end


### PR DESCRIPTION
- [x] Refactored form builder to use form builder methods. The reason for the refactoring. In a previous [PR](https://github.com/Purple-Magic/tramway/pull/37) I changed the implementation of TramwayForm Builder to use `ActionView::Base` form helpers instead of `FormBuilder` methods (both ActionView::Base and FormBuilder have their own `text_field`, `select`, .etc methods). So, I've faced some issues in forwarding the form options to ActionView::Base form helpers calls. So, I decided to send the object of class `Method` to the ViewComponent (`input` variable), so be able to call FormBuilder `text_field` directly from ViewComponent.
- [x] Fixed getting values to inputs from options or object

This refactoring was conducted to the beat of [this song](https://www.youtube.com/watch?v=IoBP24I2lwA). Please conduct your code review to the same tune, for the true harmony of programming! La la-laaa la la, la-la la-la la-laaaa!  ❤️❤️❤️❤️❤️❤️