### PR TITLE
Implemented Tramway Form inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ class Admin::UsersController < Admin::ApplicationController
 end
 ```
 
+### Form inheritance
+
+Tramway Form supports inheritance of `properties`
+
+**Example**
+
+```ruby
+class UserForm < TramwayForm
+  properties :email, :password
+end
+
+class AdminForm < TramwayForm
+  properties :permissions
+end
+
+AdminForm.properties # returns [:email, :password, :permissions]
+```
+
 ### Make flexible and extendable forms
 
 Tramway Form properties are not mapped to a model. You're able to make extended forms.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ class UserForm < TramwayForm
   properties :email, :password
 end
 
-class AdminForm < TramwayForm
+class AdminForm < UserForm
   properties :permissions
 end
 

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -30,8 +30,21 @@ module Tramway
             property(attribute)
           end
         else
-          @properties || []
+          __properties
         end
+      end
+
+      def __properties
+        @properties ||= []
+
+        (__ancestor_properties + @properties).uniq
+      end
+
+      # :reek:ManualDispatch { enabled: false }
+      def __ancestor_properties(klass = superclass)
+        return [] unless klass.respond_to?(:properties)
+
+        klass.properties + __ancestor_properties(klass.superclass)
       end
     end
 

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# :reek:ClassVariable { enabled: false }
 module Tramway
   # Provides form object for Tramway
   #
@@ -17,9 +18,17 @@ module Tramway
     end
 
     class << self
+      # rubocop:disable Style/ClassVars
+      @@properties = []
+
+      def inherited(subclass)
+        subclass.class_variable_set(:@@properties, __ancestor_properties)
+
+        super
+      end
+
       def property(attribute, _proc_obj = nil)
-        @properties ||= []
-        @properties << attribute
+        @@properties << attribute
 
         delegate attribute, to: :object
       end
@@ -35,10 +44,9 @@ module Tramway
       end
 
       def __properties
-        @properties ||= []
-
-        (__ancestor_properties + @properties).uniq
+        (__ancestor_properties + @@properties).uniq
       end
+      # rubocop:enable Style/ClassVars
 
       # :reek:ManualDispatch { enabled: false }
       def __ancestor_properties(klass = superclass)

--- a/spec/dummy/app/forms/admin_form.rb
+++ b/spec/dummy/app/forms/admin_form.rb
@@ -2,4 +2,5 @@
 
 # Test form for form-inheritance testing
 class AdminForm < UserForm
+  properties :permissions
 end

--- a/spec/dummy/app/forms/admin_form.rb
+++ b/spec/dummy/app/forms/admin_form.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Test form for form-inheritance testing
+class AdminForm < UserForm
+end

--- a/spec/dummy/app/forms/user_form.rb
+++ b/spec/dummy/app/forms/user_form.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Test form for basic functions testing
+class UserForm < Tramway::BaseForm
+  properties :email, :role
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -6,5 +6,5 @@ class User < ApplicationRecord
 
   attr_reader :password, :file
   # :reek:Attribute { enabled: false }
-  attr_accessor :role
+  attr_accessor :role, :permissions
 end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Tramway::BaseForm do
+RSpec.describe UserForm do
   context 'with persisted object' do
     let(:object) { create :user }
     subject { described_class.new(object) }

--- a/spec/forms/inheritance_form_spec.rb
+++ b/spec/forms/inheritance_form_spec.rb
@@ -1,37 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe AdminForm do
-  context 'class methods' do
-    describe '.properties' do
-      it 'returns an array with email and role' do
-        expect(AdminForm.properties).to contain_exactly(:email, :role, :permissions)
-      end
-    end
-  end
-
-  context 'instance methods' do
+  context 'properties' do
     let(:user) { build :user }
     subject { described_class.new(user) }
 
-    describe 'accessors for properties' do
-      it 'allows reading and writing for email' do
-        subject.email = 'admin@example.com'
+    let(:fields) { %i[email role permissions] }
 
-        expect(subject.email).to eq 'admin@example.com'
-      end
-
-      it 'allows reading and writing for role' do
-        subject.role = 'superadmin'
-
-        expect(subject.role).to eq 'superadmin'
+    describe 'properties field' do
+      it 'returns an array with email and role' do
+        expect(AdminForm.properties).to contain_exactly(*fields)
       end
     end
 
-    describe 'accessors for AdminForm specific properties' do
-      it 'allows reading and writing for permissions' do
-        subject.permissions = 'edit_users'
+    describe 'setting up values' do
+      it 'sets up values' do
+        fields.map do |field|
+          subject.public_send "#{field}=", 'somestr'
 
-        expect(subject.permissions).to eq 'edit_users'
+          expect(subject.send(field)).to eq 'somestr'
+        end
       end
     end
   end

--- a/spec/forms/inheritance_form_spec.rb
+++ b/spec/forms/inheritance_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe AdminForm do
+  context 'class methods' do
+    describe '.properties' do
+      it 'returns an array with email and role' do
+        expect(AdminForm.properties).to contain_exactly(:email, :role)
+      end
+    end
+  end
+
+  context 'instance methods' do
+    let(:user) { build :user }
+    subject { described_class.new(user) }
+
+    describe 'accessors for properties' do
+      it 'allows reading and writing for email' do
+        subject.email = 'admin@example.com'
+
+        expect(subject.email).to eq 'admin@example.com'
+      end
+
+      it 'allows reading and writing for role' do
+        subject.role = 'superadmin'
+
+        expect(subject.role).to eq 'superadmin'
+      end
+    end
+
+    describe 'accessors for AdminForm specific properties' do
+      before do
+        AdminForm.properties :permissions
+      end
+
+      it 'allows reading and writing for permissions' do
+        subject.permissions = 'edit_users'
+
+        expect(subject.permissions).to eq 'edit_users'
+      end
+    end
+  end
+end

--- a/spec/forms/inheritance_form_spec.rb
+++ b/spec/forms/inheritance_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AdminForm do
   context 'class methods' do
     describe '.properties' do
       it 'returns an array with email and role' do
-        expect(AdminForm.properties).to contain_exactly(:email, :role)
+        expect(AdminForm.properties).to contain_exactly(:email, :role, :permissions)
       end
     end
   end
@@ -28,10 +28,6 @@ RSpec.describe AdminForm do
     end
 
     describe 'accessors for AdminForm specific properties' do
-      before do
-        AdminForm.properties :permissions
-      end
-
       it 'allows reading and writing for permissions' do
         subject.permissions = 'edit_users'
 


### PR DESCRIPTION
## What's changed basically?

Tramway Form inheritance implemented

## What's changed for tramway drivers?
*Example*

### Before

```ruby
class UserForm < TramwayForm
  properties :email, :password
end

class AdminForm < UserForm
  properties :permissions
end

AdminForm.properties # returns [:permissions]
```

### After

```ruby
class UserForm < TramwayForm
  properties :email, :password
end

class AdminForm < UserForm
  properties :permissions
end

AdminForm.properties # returns [:email, :password, :permissions]
```

### Playlist for the code-review (Spotify)

[![image](https://github.com/Purple-Magic/tramway/assets/2001025/3f176ddf-d793-4c66-b5bf-2c2208e7b604)](https://open.spotify.com/playlist/7eWlrLB4P6qmU0u8uALzIb?si=865eb48afcd141af)

Find more info [here](https://github.com/Purple-Magic/tramway/pull/44/commits/472e77a41a4d2834a5c9d19cf86cd8a1efb59cd7)

