### PR TITLE
Implement `normalizes` in tramway form like in Rails 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Tramway provides **convenient** form objects for Rails applications. List proper
 class UserForm < Tramway::BaseForm
   properties :email, :password, :first_name, :last_name, :phone
 
-  normalizes :password, ->(value) { value if value.present? }
+  normalizes :email, ->(value) { value.strip.downcase }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,7 @@ Tramway provides **convenient** form objects for Rails applications. List proper
 class UserForm < Tramway::BaseForm
   properties :email, :password, :first_name, :last_name, :phone
 
-  def password=(value)
-    object.password = value if value.present?
-  end
+  normalizes :password, ->(value) { value if value.present? }
 end
 ```
 
@@ -249,15 +247,35 @@ class Admin::UsersController < Admin::ApplicationController
 end
 ```
 
+### Normalizes
+
+Tramway Form supports `normalizes` method. It's almost the same [as in Rails](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Normalization.html)
+
+```ruby
+class UserForm < Tramway::BaseForme
+  properties :email, :first_name, :last_name
+  
+  normalizes :email, with: ->(value) { value.strip.downcase }
+  normalizes :first_name, :last_name, with: ->(value) { value.strip }
+end
+```
+
+`normalizes` method arguments:
+* `*properties` - collection of properties that will be normalized
+* `with:` - a proc with a normalization
+* `apply_on_nil` - by default is `false`. When `true` Tramway Form applies normalization on `nil` values
+
 ### Form inheritance
 
-Tramway Form supports inheritance of `properties`
+Tramway Form supports inheritance of `properties` and `normalizations`
 
 **Example**
 
 ```ruby
 class UserForm < TramwayForm
   properties :email, :password
+
+  normalizes :email, with: ->(value) { value.strip.downcase }
 end
 
 class AdminForm < UserForm
@@ -265,6 +283,7 @@ class AdminForm < UserForm
 end
 
 AdminForm.properties # returns [:email, :password, :permissions]
+AdminForm.normalizations # contains the normalization of :email 
 ```
 
 ### Make flexible and extendable forms
@@ -274,12 +293,7 @@ Tramway Form properties are not mapped to a model. You're able to make extended 
 *app/forms/user_form.rb*
 ```ruby
 class UserForm < Tramway::BaseForm
-  properties :email, :password, :full_name
-
-  # RULE: in case password is empty, don't save
-  def password=(value)
-    object.password = value if value.present?
-  end
+  properties :email, :full_name
 
   # EXTENDED FIELD: full name
   def full_name=(value)

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -24,8 +24,8 @@ module Tramway
 
     class << self
       def inherited(subclass)
-        subclass.instance_variable_set(:@properties, [])
-        subclass.instance_variable_set(:@normalizations, {})
+        __initialize_properties subclass
+        __initialize_normalizations subclass
 
         super
       end

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -7,6 +7,9 @@ module Tramway
   # Provides form object for Tramway
   #
   class BaseForm
+    include Tramway::Forms::Properties
+    include Tramway::Forms::Normalizations
+
     attr_reader :object
 
     %i[model_name to_key to_model errors attributes].each do |method_name|
@@ -26,9 +29,6 @@ module Tramway
 
         super
       end
-
-      include Tramway::Forms::Properties
-      include Tramway::Forms::Normalizations
     end
 
     def submit(params)
@@ -63,22 +63,6 @@ module Tramway
 
     def __submit(params)
       __apply_properties __apply_normalizations params
-    end
-
-    def __apply_normalizations(params)
-      self.class.normalizations.reduce(params) do |hash, (attribute, normalization)|
-        if hash.key?(attribute) || normalization[:apply_to_nil]
-          hash.merge(attribute => instance_exec(hash[attribute], &normalization[:proc]))
-        else
-          hash
-        end
-      end
-    end
-
-    def __apply_properties(params)
-      self.class.properties.each do |attribute|
-        public_send("#{attribute}=", params[attribute]) if params.key?(attribute)
-      end
     end
 
     def __object

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -25,7 +25,7 @@ module Tramway
     class << self
       def inherited(subclass)
         subclass.instance_variable_set(:@properties, [])
-        subclass.instance_variable_set(:@normalizations, __ancestor_normalizations)
+        subclass.instance_variable_set(:@normalizations, {})
 
         super
       end

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -61,16 +61,17 @@ module Tramway
 
     private
 
-    def __apply_normalizations(params)
-      self.class.normalizations.each do |attribute, proc|
-        public_send("#{attribute}=", proc.call(params[attribute])) if params.key?(attribute)
-      end
-    end
-
     def __submit(params)
-      __apply_normalizations(params)
+      values = params
+
+      self.class.normalizations.each do |attribute, normalization|
+        if params.key?(attribute) || normalization[:apply_to_nil]
+          values[attribute] = instance_exec(params[attribute], &normalization[:proc])
+        end
+      end
+
       self.class.properties.each do |attribute|
-        public_send("#{attribute}=", params[attribute]) if params.keys.include? attribute.to_s
+        public_send("#{attribute}=", values[attribute]) if values.key?(attribute)
       end
     end
 

--- a/lib/tramway/forms/normalizations.rb
+++ b/lib/tramway/forms/normalizations.rb
@@ -5,6 +5,7 @@ module Tramway
     # This is the same `normalizes` feature like in Rails
     # https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html#method-i-normalizes
     module Normalizations
+      # :reek:BooleanParameter { enabled: false }
       def normalizes(*attributes, with:, apply_to_nil: false)
         attributes.each do |attribute|
           @normalizations.merge!(attribute => { proc: with, apply_to_nil: })

--- a/lib/tramway/forms/normalizations.rb
+++ b/lib/tramway/forms/normalizations.rb
@@ -5,24 +5,41 @@ module Tramway
     # This is the same `normalizes` feature like in Rails
     # https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html#method-i-normalizes
     module Normalizations
-      # :reek:BooleanParameter { enabled: false }
-      def normalizes(*attributes, with:, apply_to_nil: false)
-        attributes.each do |attribute|
-          @normalizations.merge!(attribute => { proc: with, apply_to_nil: })
+      # A collection of methods that would be using in users forms
+      module ClassMethods
+        # :reek:BooleanParameter { enabled: false }
+        def normalizes(*attributes, with:, apply_to_nil: false)
+          attributes.each do |attribute|
+            @normalizations.merge!(attribute => { proc: with, apply_to_nil: })
+          end
+        end
+
+        def normalizations
+          __ancestor_normalizations.merge(@normalizations)
+        end
+
+        # :reek:ManualDispatch { enabled: false }
+        def __ancestor_normalizations(klass = superclass)
+          superklass = klass.superclass
+
+          return {} unless superklass.respond_to?(:normalizations)
+
+          klass.normalizations.merge!(__ancestor_normalizations(superklass))
         end
       end
 
-      def normalizations
-        __ancestor_normalizations.merge(@normalizations)
+      def self.included(base)
+        base.extend ClassMethods
       end
 
-      # :reek:ManualDispatch { enabled: false }
-      def __ancestor_normalizations(klass = superclass)
-        superklass = klass.superclass
-
-        return {} unless superklass.respond_to?(:normalizations)
-
-        klass.normalizations.merge!(__ancestor_normalizations(superklass))
+      def __apply_normalizations(params)
+        self.class.normalizations.reduce(params) do |hash, (attribute, normalization)|
+          if hash.key?(attribute) || normalization[:apply_to_nil]
+            hash.merge(attribute => instance_exec(hash[attribute], &normalization[:proc]))
+          else
+            hash
+          end
+        end
       end
     end
   end

--- a/lib/tramway/forms/normalizations.rb
+++ b/lib/tramway/forms/normalizations.rb
@@ -26,6 +26,11 @@ module Tramway
 
           klass.normalizations.merge!(__ancestor_normalizations(superklass))
         end
+
+        # :reek:UtilityFunction { enabled: false }
+        def __initialize_normalizations(subclass)
+          subclass.instance_variable_set(:@normalizations, {})
+        end
       end
 
       def self.included(base)

--- a/lib/tramway/forms/normalizations.rb
+++ b/lib/tramway/forms/normalizations.rb
@@ -5,8 +5,10 @@ module Tramway
     # This is the same `normalizes` feature like in Rails
     # https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html#method-i-normalizes
     module Normalizations
-      def normalizes(attribute, with:)
-        @normalizations.merge!(attribute => with)
+      def normalizes(*attributes, with:, apply_to_nil: false)
+        attributes.each do |attribute|
+          @normalizations.merge!(attribute => { proc: with, apply_to_nil: })
+        end
       end
 
       def normalizations

--- a/lib/tramway/forms/normalizations.rb
+++ b/lib/tramway/forms/normalizations.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Tramway
+  module Forms
+    # This is the same `normalizes` feature like in Rails
+    # https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Normalization/ClassMethods.html#method-i-normalizes
+    module Normalizations
+      def normalizes(attribute, with:)
+        @normalizations.merge!(attribute => with)
+      end
+
+      def normalizations
+        __ancestor_normalizations.merge(@normalizations)
+      end
+
+      # :reek:ManualDispatch { enabled: false }
+      def __ancestor_normalizations(klass = superclass)
+        superklass = klass.superclass
+
+        return {} unless superklass.respond_to?(:normalizations)
+
+        klass.normalizations.merge!(__ancestor_normalizations(superklass))
+      end
+    end
+  end
+end

--- a/lib/tramway/forms/properties.rb
+++ b/lib/tramway/forms/properties.rb
@@ -34,6 +34,11 @@ module Tramway
 
           klass.properties + __ancestor_properties(superklass)
         end
+
+        # :reek:UtilityFunction { enabled: false }
+        def __initialize_properties(subclass)
+          subclass.instance_variable_set(:@properties, [])
+        end
       end
 
       def self.included(base)

--- a/lib/tramway/forms/properties.rb
+++ b/lib/tramway/forms/properties.rb
@@ -4,33 +4,49 @@ module Tramway
   module Forms
     # This is `properties`. The main feature of Tramway Form
     module Properties
-      def property(attribute)
-        @properties << attribute
+      # A collection of methods that would be using in users forms
+      module ClassMethods
+        def property(attribute)
+          @properties << attribute
 
-        delegate attribute, to: :object
-      end
+          delegate attribute, to: :object
+        end
 
-      def properties(*attributes)
-        attributes.any? ? __set_properties(attributes) : __properties
-      end
+        def properties(*attributes)
+          attributes.any? ? __set_properties(attributes) : __properties
+        end
 
-      def __set_properties(attributes)
-        attributes.each do |attribute|
-          property(attribute)
+        def __set_properties(attributes)
+          attributes.each do |attribute|
+            property(attribute)
+          end
+        end
+
+        def __properties
+          (__ancestor_properties + @properties).uniq
+        end
+
+        # :reek:ManualDispatch { enabled: false }
+        def __ancestor_properties(klass = superclass)
+          superklass = klass.superclass
+
+          return [] unless superklass.respond_to?(:properties)
+
+          klass.properties + __ancestor_properties(superklass)
         end
       end
 
-      def __properties
-        (__ancestor_properties + @properties).uniq
+      def self.included(base)
+        base.extend ClassMethods
+        base.class_eval do
+          @properties = []
+        end
       end
 
-      # :reek:ManualDispatch { enabled: false }
-      def __ancestor_properties(klass = superclass)
-        superklass = klass.superclass
-
-        return [] unless superklass.respond_to?(:properties)
-
-        klass.properties + __ancestor_properties(superklass)
+      def __apply_properties(params)
+        self.class.properties.each do |attribute|
+          public_send("#{attribute}=", params[attribute]) if params.key?(attribute)
+        end
       end
     end
   end

--- a/lib/tramway/forms/properties.rb
+++ b/lib/tramway/forms/properties.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Tramway
+  module Forms
+    # This is `properties`. The main feature of Tramway Form
+    module Properties
+      def property(attribute)
+        @properties << attribute
+
+        delegate attribute, to: :object
+      end
+
+      def properties(*attributes)
+        attributes.any? ? __set_properties(attributes) : __properties
+      end
+
+      def __set_properties(attributes)
+        attributes.each do |attribute|
+          property(attribute)
+        end
+      end
+
+      def __properties
+        (__ancestor_properties + @properties).uniq
+      end
+
+      # :reek:ManualDispatch { enabled: false }
+      def __ancestor_properties(klass = superclass)
+        superklass = klass.superclass
+
+        return [] unless superklass.respond_to?(:properties)
+
+        klass.properties + __ancestor_properties(superklass)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/forms/admin_form.rb
+++ b/spec/dummy/app/forms/admin_form.rb
@@ -3,4 +3,6 @@
 # Test form for form-inheritance testing
 class AdminForm < UserForm
   properties :permissions
+
+  normalizes :permissions, with: ->(value) { value.is_a?(Array) ? value : value.split(',') }
 end

--- a/spec/dummy/app/forms/admin_form.rb
+++ b/spec/dummy/app/forms/admin_form.rb
@@ -5,5 +5,5 @@ class AdminForm < UserForm
   properties :permissions, :first_name, :last_name
 
   normalizes :permissions, with: ->(value) { value.is_a?(Array) ? value : value.split(',') }
-  normalizes :first_name, :last_name, with: ->(value) { value.strip }
+  normalizes :first_name, :last_name, with: ->(value) { value&.strip }
 end

--- a/spec/dummy/app/forms/admin_form.rb
+++ b/spec/dummy/app/forms/admin_form.rb
@@ -2,7 +2,8 @@
 
 # Test form for form-inheritance testing
 class AdminForm < UserForm
-  properties :permissions
+  properties :permissions, :first_name, :last_name
 
   normalizes :permissions, with: ->(value) { value.is_a?(Array) ? value : value.split(',') }
+  normalizes :first_name, :last_name, with: ->(value) { value.strip }
 end

--- a/spec/dummy/app/forms/user_form.rb
+++ b/spec/dummy/app/forms/user_form.rb
@@ -3,4 +3,6 @@
 # Test form for basic functions testing
 class UserForm < Tramway::BaseForm
   properties :email, :role
+
+  normalizes :email, with: ->(value) { value.strip.downcase }
 end

--- a/spec/dummy/app/forms/user_form.rb
+++ b/spec/dummy/app/forms/user_form.rb
@@ -4,5 +4,5 @@
 class UserForm < Tramway::BaseForm
   properties :email, :role
 
-  normalizes :email, with: ->(value) { value.strip.downcase }
+  normalizes :email, with: ->(value) { value&.strip&.downcase }
 end

--- a/spec/dummy/db/migrate/20230627061428_create_users.rb
+++ b/spec/dummy/db/migrate/20230627061428_create_users.rb
@@ -3,10 +3,10 @@
 class CreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|
-      t.string :email,              null: false, default: ''
-      t.string :first_name,         null: false, default: ''
-      t.string :last_name,          null: false, default: ''
-      t.string :encrypted_password, null: false, default: ''
+      t.string :email
+      t.string :first_name
+      t.string :last_name
+      t.string :encrypted_password
 
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at

--- a/spec/dummy/db/migrate/20230627061428_create_users.rb
+++ b/spec/dummy/db/migrate/20230627061428_create_users.rb
@@ -4,6 +4,8 @@ class CreateUsers < ActiveRecord::Migration[7.0]
   def change
     create_table :users do |t|
       t.string :email,              null: false, default: ''
+      t.string :first_name,         null: false, default: ''
+      t.string :last_name,          null: false, default: ''
       t.string :encrypted_password, null: false, default: ''
 
       t.string   :reset_password_token

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -22,10 +22,10 @@ ActiveRecord::Schema[7.1].define(version: 20_240_103_082_421) do
   end
 
   create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'first_name', default: '', null: false
-    t.string 'last_name', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
+    t.string 'email'
+    t.string 'first_name'
+    t.string 'last_name'
+    t.string 'encrypted_password'
     t.string 'reset_password_token'
     t.datetime 'reset_password_sent_at'
     t.datetime 'remember_created_at'

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -23,6 +23,8 @@ ActiveRecord::Schema[7.1].define(version: 20_240_103_082_421) do
 
   create_table 'users', force: :cascade do |t|
     t.string 'email', default: '', null: false
+    t.string 'first_name', default: '', null: false
+    t.string 'last_name', default: '', null: false
     t.string 'encrypted_password', default: '', null: false
     t.string 'reset_password_token'
     t.datetime 'reset_password_sent_at'

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -22,13 +22,25 @@ RSpec.describe UserForm do
     end
 
     describe '#submit' do
-      let(:params) { { email: 'asya@purple-magic.com' } }
+      context 'with default checks' do
+        let(:params) { { email: 'asya@purple-magic.com' } }
 
-      it 'updates object attributes and saves it' do
-        expect(object).to receive(:save).and_return(true)
-        expect(object).to receive(:reload)
+        it 'updates object attributes and saves it' do
+          expect(object).to receive(:save).and_return(true)
+          expect(object).to receive(:reload)
 
-        subject.submit(params)
+          subject.submit(params)
+        end
+      end
+
+      context 'with normalizes checks' do
+        let(:params) { { email: 'Asya@Purple-Magic.com' } }
+
+        it 'updates object attributes and saves it' do
+          subject.submit(params)
+
+          expect(object.email).to eq 'asya@purple-magic.com'
+        end
       end
     end
 

--- a/spec/forms/inheritance_form_spec.rb
+++ b/spec/forms/inheritance_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AdminForm do
     let(:user) { build :user }
     subject { described_class.new(user) }
 
-    let(:fields) { %i[email role permissions] }
+    let(:fields) { %i[email first_name last_name role permissions] }
 
     describe 'properties field' do
       it 'returns an array with email and role' do
@@ -28,7 +28,7 @@ RSpec.describe AdminForm do
     let(:user) { build :user }
     subject { described_class.new(user) }
 
-    let(:fields) { %i[email permissions] }
+    let(:fields) { %i[email first_name last_name permissions] }
 
     describe 'properties field' do
       it 'returns an array with email and role' do

--- a/spec/forms/inheritance_form_spec.rb
+++ b/spec/forms/inheritance_form_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe AdminForm do
       end
     end
   end
+
+  context 'normalizes' do
+    let(:user) { build :user }
+    subject { described_class.new(user) }
+
+    let(:fields) { %i[email permissions] }
+
+    describe 'properties field' do
+      it 'returns an array with email and role' do
+        expect(AdminForm.normalizations.keys).to contain_exactly(*fields)
+      end
+    end
+  end
 end

--- a/spec/forms/normalizes_form_spec.rb
+++ b/spec/forms/normalizes_form_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Tramway::BaseForm do
+  class TestForm < Tramway::BaseForm
+    normalizes :email, with: ->(value) { value.strip.downcase }
+  end
+
+  let(:user) { build(:user) }
+  let(:form) { TestForm.new(user) }
+
+  describe '#submit with normalization' do
+    it 'normalizes email before saving' do
+      params = { email: ' Example@Email.Com ' }
+      expect(user).to receive(:email=).with('example@email.com')
+      expect(user).to receive(:save).and_return(true)
+      form.submit(params)
+    end
+  end
+
+  context 'with normalization rule for non-existing attribute' do
+    it 'ignores normalization for non-defined attributes' do
+      params = { non_existing_attribute: ' some value ' }
+      expect { form.submit(params) }.not_to raise_error
+    end
+  end
+end

--- a/spec/forms/normalizes_form_spec.rb
+++ b/spec/forms/normalizes_form_spec.rb
@@ -1,16 +1,16 @@
-RSpec.describe Tramway::BaseForm do
-  class TestForm < Tramway::BaseForm
-    normalizes :email, with: ->(value) { value.strip.downcase }
-  end
+# frozen_string_literal: true
 
+RSpec.describe Tramway::BaseForm do
   let(:user) { build(:user) }
-  let(:form) { TestForm.new(user) }
+  let(:form) { UserForm.new(user) }
 
   describe '#submit with normalization' do
     it 'normalizes email before saving' do
       params = { email: ' Example@Email.Com ' }
+
       expect(user).to receive(:email=).with('example@email.com')
       expect(user).to receive(:save).and_return(true)
+
       form.submit(params)
     end
   end
@@ -18,6 +18,7 @@ RSpec.describe Tramway::BaseForm do
   context 'with normalization rule for non-existing attribute' do
     it 'ignores normalization for non-defined attributes' do
       params = { non_existing_attribute: ' some value ' }
+
       expect { form.submit(params) }.not_to raise_error
     end
   end

--- a/spec/forms/normalizes_form_spec.rb
+++ b/spec/forms/normalizes_form_spec.rb
@@ -18,6 +18,23 @@ describe 'Normalization' do
         expect(user.last_name).to eq 'Selezneva'
       end
     end
+
+    context 'when normalizing attributes with apply_on_nil: true' do
+      it 'applies normalization to nil values' do
+        AdminForm.new(user).submit(first_name: nil, last_name: nil)
+
+        expect(user.first_name).to be_nil
+        expect(user.last_name).to be_nil
+      end
+    end
+
+    context 'when normalizing attributes without apply_on_nil' do
+      it 'does not apply normalization to nil values' do
+        UserForm.new(user).submit(email: nil)
+
+        expect(user.email).to eq nil
+      end
+    end
   end
 
   context 'inheritance and extension' do


### PR DESCRIPTION
## What's changed basically?

Rails 7.1 provided us with a new feature in ActiveRecord [normalizes](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Normalization.html).

[Useful article about](https://www.shakacode.com/blog/rails-add-normalize-to-activerecord/)

Here we added almost the same feature to Tramway Form

## What's changed for tramway drivers?

*Example*

### Before

```ruby
class UserForm < Tramway::BaseForme
  properties :email
  
  def email=(value)
    object.email = value.strip.downcase
  end
end
```

### After

```ruby
class UserForm < Tramway::BaseForme
  properties :email
  
  normalizes :email, with: ->(value) { value.strip.downcase }
end
```

It also supports arguments:
* `apply_to_nil`: by default is `false`. Defined normalization are not applied to nil values.
* multiple attributes `normalizes :first_name, :last_name, with: ->(value) { value.strip }`
* **Inheritance**. Tramway Form inherits normalizations from its ancestors

It **does not** support:
* object-level `normalize_attribute` method
* class-level `normalize` method

