### PR TITLE
Issue #51. Delegate update and destroy methods to Tramway Decorator

### DIFF
--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -12,7 +12,7 @@ module Tramway
 
     attr_reader :object
 
-    %i[model_name to_key to_model errors attributes].each do |method_name|
+    %i[model_name to_key to_model errors attributes update destroy].each do |method_name|
       delegate method_name, to: :object
     end
 

--- a/spec/forms/delegation_form_spec.rb
+++ b/spec/forms/delegation_form_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Tramway::BaseForm do
+  let(:user) { create(:user) }
+  let(:form) { described_class.new(user) }
+
+  describe '#update' do
+    let(:attributes) { { email: 'updated@example.com' } }
+
+    it 'updates the object with given attributes' do
+      expect(user).to receive(:update).with(attributes).and_return(true)
+
+      expect(form.update(attributes)).to be true
+    end
+  end
+
+  describe '#destroy' do
+    it 'destroys the object' do
+      expect(user).to receive(:destroy)
+
+      form.destroy
+    end
+  end
+end


### PR DESCRIPTION
## What's changed basically?

Delegated `update` and `destroy` methods to Tramway Decorator.

## What's changed for tramway drivers?

### Before

```ruby
user = tramway_decorate User.first
user.object.destroy
```

### After

```ruby
user = tramway_decorate User.first
user.destroy
```
