### PR TITLE
Add assign method to Tramway Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,21 @@ class UserForm < Tramway::BaseForm
 end
 ```
 
-#### Update and Destroy
+### Assign values
+
+Tramway Form provides `assign` method that allows to assign values without saving
+
+```ruby
+class UsersController < ApplicationController
+  def update
+    @user = tramway_form User.new
+    @user.assign params[:user] # assigns values to the form object
+    @user.reload # restores previous values
+  end
+end
+```
+
+### Update and Destroy
 
 Read [behave_as_ar](https://github.com/Purple-Magic/tramway#behave_as_ar) section
 

--- a/lib/tramway/base_form.rb
+++ b/lib/tramway/base_form.rb
@@ -45,6 +45,10 @@ module Tramway
       end
     end
 
+    def assign(params)
+      __submit params
+    end
+
     def method_missing(method_name, *args)
       if method_name.to_s.end_with?('=') && args.count == 1
         object.public_send(method_name, args.first)

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe UserForm do
       end
     end
 
+    describe '#assign' do
+      let(:params) { { email: 'asya@purple-magic.com' } }
+
+      it 'just assigns object attributes' do
+        expect(object).not_to receive(:save!)
+        expect(object).not_to receive(:reload)
+        subject.assign(params)
+        expect(object.email).to eq 'asya@purple-magic.com'
+      end
+    end
+
     context 'method delegation' do
       it 'delegates certain methods to the object' do
         methods_to_delegate = %i[id model_name to_key errors attributes]


### PR DESCRIPTION
## What's changed basically?

Added `assign` method to Tramway Form.

## What's changed for tramway drivers?

Tramway Form provides `assign` method that allows to assign values without saving

```ruby
class UsersController < ApplicationController
  def update
    @user = tramway_form User.new
    @user.assign params[:user] # assigns values to the form object
    @user.reload # restores previous values
  end
end
```

[PLAYLIST for review](https://open.spotify.com/playlist/73x3QF3MEaMtLoazPozrj4?si=fdce3bf3f58f4be3)
