### PR TITLE
Issue #69. Add tramway_decorate method to tramway_form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in tramway.gemspec.
 gemspec
 
+gem 'aasm'
 gem 'anyway_config'
 gem 'dry-initializer'
 gem 'haml-rails'

--- a/lib/tramway/base_decorator.rb
+++ b/lib/tramway/base_decorator.rb
@@ -3,6 +3,7 @@
 require 'tramway/decorators/name_builder'
 require 'tramway/decorators/association'
 require 'tramway/decorators/collection_decorator'
+require 'tramway/helpers/decorate_helper'
 require 'tramway/utils/render'
 require 'tramway/duck_typing'
 
@@ -13,6 +14,7 @@ module Tramway
     include Tramway::Decorators::CollectionDecorators
     include Tramway::Utils::Render
     include Tramway::DuckTyping::ActiveRecordCompatibility
+    include Tramway::Helpers::DecorateHelper
 
     attr_reader :object
 

--- a/lib/tramway/helpers/decorate_helper.rb
+++ b/lib/tramway/helpers/decorate_helper.rb
@@ -10,6 +10,8 @@ module Tramway
       def tramway_decorate(object_or_array, decorator: nil)
         return [] if Tramway::Decorators::CollectionDecorators.collection?(object_or_array) && object_or_array.empty?
 
+        return nil if object_or_array.nil?
+
         Tramway::Decorators::ClassHelper.decorator_class(object_or_array, decorator).decorate object_or_array
       end
     end

--- a/spec/decorators/base_decorator_spec.rb
+++ b/spec/decorators/base_decorator_spec.rb
@@ -8,7 +8,7 @@ shared_examples 'Decorate Collection' do
   end
 end
 
-RSpec.describe Tramway::BaseDecorator do
+describe Tramway::BaseDecorator do
   subject(:decorated_object) { described_class.new(object) }
 
   let(:object) { User.first }

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe UserDecorator do
+  subject(:decorated_object) { described_class.new(object) }
+
+  let(:object) { create :user, :with_posts }
+
+  describe '#published_posts' do
+    it 'returns empty collection' do
+      expect(decorated_object.published_posts).to be_empty
+    end
+  end
+end

--- a/spec/dummy/app/decorators/user_decorator.rb
+++ b/spec/dummy/app/decorators/user_decorator.rb
@@ -2,4 +2,8 @@
 
 class UserDecorator < Tramway::BaseDecorator
   association :posts
+
+  def published_posts
+    tramway_decorate object.posts.published
+  end
 end

--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -3,4 +3,6 @@
 # Base model for the whole dummy application
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  include AASM
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -3,4 +3,13 @@
 # Test model
 class Post < ApplicationRecord
   belongs_to :user
+
+  aasm do
+    state :draft, initial: true
+    state :published
+
+    event :publish do
+      transitions from: :draft, to: :published
+    end
+  end
 end

--- a/spec/dummy/db/migrate/20240720025030_add_aasm_state_to_posts.rb
+++ b/spec/dummy/db/migrate/20240720025030_add_aasm_state_to_posts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAasmStateToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :aasm_state, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -12,13 +12,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_103_082_421) do
+ActiveRecord::Schema[7.1].define(version: 20_240_720_025_030) do
   create_table 'posts', force: :cascade do |t|
     t.integer 'user_id'
     t.string 'title'
     t.string 'text'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.string 'aasm_state'
   end
 
   create_table 'users', force: :cascade do |t|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user
+  factory :user do
+    trait :with_posts do
+      after :create do |u|
+        create :post, user: u
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What's changed basically?

* `tramway_decorate` method is available inside Tramway Decorator class

## What's changed for tramway drivers?

### Before

```ruby
class UserDecorator < Tramway::BaseDecorator
  def published_posts
    PostDecorator.decorate object.posts.published
  end
end
```

### After

```ruby
class UserDecorator < Tramway::BaseDecorator
  def published_posts
    tramway_decorate object.posts.published
  end
end
```